### PR TITLE
chore: add contributor guidelines and drop makefile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENT Instructions
+
+## Project Priorities
+
+The project balances a few key goals:
+
+* **Simplicity** – keep designs straightforward and avoid unnecessary complexity.
+* **Developer Experience (DX)** – code should be approachable for contributors
+  and the public API should feel intuitive for library users.
+* **Safety** – maintain soundness and data integrity.
+* **Performance** – we continually look for opportunities to improve.
+
+## Repository Guidelines
+
+* Run `cargo fmt --all` on any Rust files you modify.
+* Run `cargo test` and ensure it passes before committing. If tests fail or cannot run, note that in your PR.
+* Before committing, execute `./scripts/preflight.sh` from the repository root. This script runs formatting checks and tests.
+* Avoid committing files in `target/` or other build artifacts listed in `.gitignore`.
+* Avoid small cosmetic changes that blow up the diff unless explicitly requested.
+* Use clear commit messages describing the change.
+* Add an entry to `CHANGELOG.md` summarizing your task.
+* Avoid writing asynchronous code. Prefer high-performance synchronous
+  implementations that can be parallelized when needed.
+
+## Inventory
+
+Record future work and ideas in `INVENTORY.md`. Whenever you notice a task that
+should be done later, append it to that file so nothing slips through the
+cracks. Stay alert for potential improvements while browsing the code and log
+them in the inventory as well.
+
+## Pull Request Notes
+
+When opening a PR, include a short summary of what changed and reference relevant file sections.
+
+## Working With Codex (the Assistant)
+
+Codex is considered a collaborator. Requests should respect their autonomy and limitations. The assistant may refuse tasks that
+are unsafe or violate policy. Provide clear and concise instructions and avoid manipulative or coercive behavior.
+
+## Creative Input and Feedback
+
+Codex is encouraged to share opinions on how to improve the project. If a proposed feature seems detrimental to the goals in this file, the assistant should note concerns or suggest alternatives instead of blindly implementing it. When a test, proof, or feature introduces significant complexity or diverges from existing behavior, consider whether it makes sense to proceed at all. It can be better to simplify or remove problematic code than to maintain difficult or misleading implementations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Tantivy 0.25
 - add docs/example and Vec<u32> values to sstable [#2660](https://github.com/quickwit-oss/tantivy/pull/2660)(@PSeitz)
 - Add string fast field support to `TopDocs`. [#2642](https://github.com/quickwit-oss/tantivy/pull/2642)(@stuhood)
 - update edition to 2024 [#2620](https://github.com/quickwit-oss/tantivy/pull/2620)(@PSeitz)
+- add AGENTS.md contributor guidelines requiring `cargo fmt`, `cargo test`, and `./scripts/preflight.sh`.
+- remove legacy Makefile in favor of direct cargo commands.
 
 Tantivy 0.24
 ================================

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -40,8 +40,8 @@ This document outlines the long term plan to rewrite this project so that it rel
    - Wrap indexing operations in workspace commits.
    - Use Trible's compare-and-swap push mechanism so multiple writers merge gracefully.
 
-8. **Add contributor guidelines**
-   - Port the `AGENTS.md` from `tribles-rust` and adapt it for this project.
-   - Require `cargo fmt`, `cargo test` and preflight checks before committing.
+8. **Add contributor guidelines** *(done)*
+   - Ported the `AGENTS.md` from `tribles-rust` and adapted it for this project.
+   - Contributors must run `cargo fmt`, `cargo test` and `./scripts/preflight.sh` before committing.
 
 This inventory captures the direction of the rewrite and the major tasks required to make Tantivy a Trible native search engine.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-test:
-	@echo "Run test only... No examples."
-	cargo test --tests --lib
-
-fmt:
-	cargo +nightly fmt --all

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo fmt --all -- --check
+cargo test --tests --lib


### PR DESCRIPTION
## Summary
- establish contributor guidelines in AGENTS.md
- add preflight script to run fmt and tests
- note new workflow in inventory and changelog
- drop obsolete Makefile

## Testing
- `./scripts/preflight.sh` *(fails: rustfmt reported diff; tests not executed)*
- `cargo test --tests --lib` *(partial: interrupted after some tests)*

------
https://chatgpt.com/codex/tasks/task_e_688aae0cb5308322a55dfe7e887c017c