### PR TITLE
Remove custom rustfmt configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Tantivy 0.25
 - update edition to 2024 [#2620](https://github.com/quickwit-oss/tantivy/pull/2620)(@PSeitz)
 - add AGENTS.md contributor guidelines requiring `cargo fmt`, `cargo test`, and `./scripts/preflight.sh`.
 - remove legacy Makefile in favor of direct cargo commands.
+- remove custom `rustfmt` configuration in favor of default formatting.
 
 Tantivy 0.24
 ================================

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -43,5 +43,7 @@ This document outlines the long term plan to rewrite this project so that it rel
 8. **Add contributor guidelines** *(done)*
    - Ported the `AGENTS.md` from `tribles-rust` and adapted it for this project.
    - Contributors must run `cargo fmt`, `cargo test` and `./scripts/preflight.sh` before committing.
+9. **Clean up unused imports**
+   - `cargo test` reports several `unused import: std::iter` warnings that should be removed.
 
 This inventory captures the direction of the rewrite and the major tasks required to make Tantivy a Trible native search engine.

--- a/columnar/src/block_accessor.rs
+++ b/columnar/src/block_accessor.rs
@@ -81,7 +81,9 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
 /// Given two sorted lists of docids `docs` and `hits`, hits is a subset of `docs`.
 /// Return all docs that are not in `hits`.
 fn find_missing_docs<F>(docs: &[u32], hits: &[u32], mut callback: F)
-where F: FnMut(u32) {
+where
+    F: FnMut(u32),
+{
     let mut docs_iter = docs.iter();
     let mut hits_iter = hits.iter();
 

--- a/columnar/src/column_index/optional_index/mod.rs
+++ b/columnar/src/column_index/optional_index/mod.rs
@@ -176,7 +176,8 @@ impl SelectCursor<RowId> for OptionalIndexSelectCursor<'_> {
 impl Set<RowId> for OptionalIndex {
     type SelectCursor<'b>
         = OptionalIndexSelectCursor<'b>
-    where Self: 'b;
+    where
+        Self: 'b;
     // Check if value at position is not null.
     #[inline]
     fn contains(&self, row_id: RowId) -> bool {

--- a/columnar/src/column_index/optional_index/set.rs
+++ b/columnar/src/column_index/optional_index/set.rs
@@ -23,7 +23,8 @@ pub trait SelectCursor<T> {
 
 pub trait Set<T> {
     type SelectCursor<'b>: SelectCursor<T>
-    where Self: 'b;
+    where
+        Self: 'b;
 
     /// Returns true if the elements is contained in the Set
     fn contains(&self, el: T) -> bool;

--- a/columnar/src/column_index/optional_index/set_block/dense.rs
+++ b/columnar/src/column_index/optional_index/set_block/dense.rs
@@ -124,7 +124,8 @@ impl SelectCursor<u16> for DenseBlockSelectCursor<'_> {
 impl<'a> Set<u16> for DenseBlock<'a> {
     type SelectCursor<'b>
         = DenseBlockSelectCursor<'a>
-    where Self: 'b;
+    where
+        Self: 'b;
 
     #[inline(always)]
     fn contains(&self, el: u16) -> bool {

--- a/columnar/src/column_index/optional_index/set_block/sparse.rs
+++ b/columnar/src/column_index/optional_index/set_block/sparse.rs
@@ -34,7 +34,8 @@ impl<'a> SelectCursor<u16> for SparseBlock<'a> {
 impl Set<u16> for SparseBlock<'_> {
     type SelectCursor<'b>
         = Self
-    where Self: 'b;
+    where
+        Self: 'b;
 
     #[inline(always)]
     fn contains(&self, el: u16) -> bool {

--- a/columnar/src/column_values/monotonic_mapping.rs
+++ b/columnar/src/column_values/monotonic_mapping.rs
@@ -56,7 +56,8 @@ impl<T> From<T> for StrictlyMonotonicMappingInverter<T> {
 }
 
 impl<From, To, T> StrictlyMonotonicFn<To, From> for StrictlyMonotonicMappingInverter<T>
-where T: StrictlyMonotonicFn<From, To>
+where
+    T: StrictlyMonotonicFn<From, To>,
 {
     #[inline(always)]
     fn mapping(&self, val: To) -> From {
@@ -84,7 +85,8 @@ impl<T> StrictlyMonotonicMappingToInternal<T> {
 
 impl<External: MonotonicallyMappableToU128, T: MonotonicallyMappableToU128>
     StrictlyMonotonicFn<External, u128> for StrictlyMonotonicMappingToInternal<T>
-where T: MonotonicallyMappableToU128
+where
+    T: MonotonicallyMappableToU128,
 {
     #[inline(always)]
     fn mapping(&self, inp: External) -> u128 {
@@ -99,7 +101,8 @@ where T: MonotonicallyMappableToU128
 
 impl<External: MonotonicallyMappableToU64, T: MonotonicallyMappableToU64>
     StrictlyMonotonicFn<External, u64> for StrictlyMonotonicMappingToInternal<T>
-where T: MonotonicallyMappableToU64
+where
+    T: MonotonicallyMappableToU64,
 {
     #[inline(always)]
     fn mapping(&self, inp: External) -> u64 {

--- a/columnar/src/columnar/reader/mod.rs
+++ b/columnar/src/columnar/reader/mod.rs
@@ -93,7 +93,9 @@ fn column_dictionary_prefix_for_subpath(root_path: &str) -> String {
 impl ColumnarReader {
     /// Opens a new Columnar file.
     pub fn open<F>(file_slice: F) -> io::Result<ColumnarReader>
-    where FileSlice: From<F> {
+    where
+        FileSlice: From<F>,
+    {
         Self::open_inner(file_slice.into())
     }
 

--- a/columnar/src/columnar/writer/mod.rs
+++ b/columnar/src/columnar/writer/mod.rs
@@ -645,7 +645,9 @@ fn sort_values_within_row_in_place(
 fn coerce_numerical_symbol<T>(
     operation_iterator: impl Iterator<Item = ColumnOperation<NumericalValue>>,
 ) -> impl Iterator<Item = ColumnOperation<u64>>
-where T: Coerce + MonotonicallyMappableToU64 {
+where
+    T: Coerce + MonotonicallyMappableToU64,
+{
     operation_iterator.map(|symbol| match symbol {
         ColumnOperation::NewDoc(doc) => ColumnOperation::NewDoc(doc),
         ColumnOperation::Value(numerical_value) => {

--- a/columnar/src/iterable.rs
+++ b/columnar/src/iterable.rs
@@ -14,7 +14,8 @@ impl<T: Copy> Iterable<T> for &[T] {
 }
 
 impl<T: Copy> Iterable<T> for Range<T>
-where Range<T>: Iterator<Item = T>
+where
+    Range<T>: Iterator<Item = T>,
 {
     fn boxed_iter(&self) -> Box<dyn Iterator<Item = T> + '_> {
         Box::new(self.clone())

--- a/common/src/file_slice.rs
+++ b/common/src/file_slice.rs
@@ -103,7 +103,8 @@ impl FileHandle for &'static [u8] {
 }
 
 impl<B> From<B> for FileSlice
-where B: StableDeref + Deref<Target = [u8]> + 'static + Send + Sync
+where
+    B: StableDeref + Deref<Target = [u8]> + 'static + Send + Sync,
 {
     fn from(bytes: B) -> FileSlice {
         FileSlice::new(Arc::new(OwnedBytes::new(bytes)))

--- a/common/src/writer.rs
+++ b/common/src/writer.rs
@@ -65,7 +65,9 @@ pub struct AntiCallToken(());
 pub trait TerminatingWrite: Write + Send + Sync {
     /// Indicate that the writer will no longer be used. Internally call terminate_ref.
     fn terminate(mut self) -> io::Result<()>
-    where Self: Sized {
+    where
+        Self: Sized,
+    {
         self.terminate_ref(AntiCallToken(()))
     }
 

--- a/ownedbytes/src/lib.rs
+++ b/ownedbytes/src/lib.rs
@@ -181,7 +181,8 @@ impl PartialEq<str> for OwnedBytes {
 }
 
 impl<'a, T: ?Sized> PartialEq<&'a T> for OwnedBytes
-where OwnedBytes: PartialEq<T>
+where
+    OwnedBytes: PartialEq<T>,
 {
     fn eq(&self, other: &&'a T) -> bool {
         *self == **other

--- a/query-grammar/src/infallible.rs
+++ b/query-grammar/src/infallible.rs
@@ -46,7 +46,9 @@ fn unwrap_infallible<T>(res: Result<T, nom::Err<Infallible>>) -> T {
 ///
 /// It's less generic than the original to ease type resolution in the rest of the code.
 pub(crate) fn opt_i<I: Clone, O, F>(mut f: F) -> impl FnMut(I) -> JResult<I, Option<O>>
-where F: nom::Parser<I, O, nom::error::Error<I>> {
+where
+    F: nom::Parser<I, O, nom::error::Error<I>>,
+{
     move |input: I| {
         let i = input.clone();
         match f.parse(input) {
@@ -106,7 +108,9 @@ where
 pub(crate) fn fallible<I, O, E: nom::error::ParseError<I>, F>(
     mut f: F,
 ) -> impl FnMut(I) -> IResult<I, O, E>
-where F: nom::Parser<I, (O, ErrorList), Infallible> {
+where
+    F: nom::Parser<I, (O, ErrorList), Infallible>,
+{
     use nom::Err;
     move |input: I| match f.parse(input) {
         Ok((input, (output, _err))) => Ok((input, output)),

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,0 @@
-comment_width = 120
-format_strings = true
-group_imports = "StdExternalCrate"
-imports_granularity = "Module"
-normalize_comments = true
-where_single_line = true
-wrap_comments = true

--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -188,7 +188,9 @@ pub struct HistogramBounds {
 }
 
 fn deserialize_date_or_num<'de, D>(deserializer: D) -> Result<f64, D::Error>
-where D: serde::Deserializer<'de> {
+where
+    D: serde::Deserializer<'de>,
+{
     let value: serde_json::Value = Deserialize::deserialize(deserializer)?;
 
     // Check if the value is a string representing an Rfc3339 formatted date

--- a/src/aggregation/bucket/mod.rs
+++ b/src/aggregation/bucket/mod.rs
@@ -102,7 +102,9 @@ pub struct CustomOrder {
 
 impl Serialize for CustomOrder {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: Serializer {
+    where
+        S: Serializer,
+    {
         let map: HashMap<String, Order> =
             std::iter::once((self.target.to_string(), self.order)).collect();
         map.serialize(serializer)
@@ -111,7 +113,9 @@ impl Serialize for CustomOrder {
 
 impl<'de> Deserialize<'de> for CustomOrder {
     fn deserialize<D>(deserializer: D) -> Result<CustomOrder, D::Error>
-    where D: Deserializer<'de> {
+    where
+        D: Deserializer<'de>,
+    {
         let value = serde_json::Value::deserialize(deserializer)?;
         let return_err = |message, val: serde_json::Value| {
             de::Error::custom(format!(

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -124,7 +124,9 @@ impl Serialize for KeyOrder {
 
 impl<'de> Deserialize<'de> for KeyOrder {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: Deserializer<'de> {
+    where
+        D: Deserializer<'de>,
+    {
         let mut key_order = <HashMap<String, Order>>::deserialize(deserializer)?.into_iter();
         let (field, order) = key_order.next().ok_or(serde::de::Error::custom(
             "Expected exactly one key-value pair in sort parameter of top_hits, found none",

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -177,7 +177,9 @@ fn parse_str_into_f64<E: de::Error>(value: &str) -> Result<f64, E> {
 
 /// deserialize Option<f64> from string or float
 pub(crate) fn deserialize_option_f64<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
-where D: Deserializer<'de> {
+where
+    D: Deserializer<'de>,
+{
     struct StringOrFloatVisitor;
 
     impl Visitor<'_> for StringOrFloatVisitor {
@@ -188,32 +190,44 @@ where D: Deserializer<'de> {
         }
 
         fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-        where E: de::Error {
+        where
+            E: de::Error,
+        {
             parse_str_into_f64(value).map(Some)
         }
 
         fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
-        where E: de::Error {
+        where
+            E: de::Error,
+        {
             Ok(Some(value))
         }
 
         fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
-        where E: de::Error {
+        where
+            E: de::Error,
+        {
             Ok(Some(value as f64))
         }
 
         fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
-        where E: de::Error {
+        where
+            E: de::Error,
+        {
             Ok(Some(value as f64))
         }
 
         fn visit_none<E>(self) -> Result<Self::Value, E>
-        where E: de::Error {
+        where
+            E: de::Error,
+        {
             Ok(None)
         }
 
         fn visit_unit<E>(self) -> Result<Self::Value, E>
-        where E: de::Error {
+        where
+            E: de::Error,
+        {
             Ok(None)
         }
     }
@@ -223,7 +237,9 @@ where D: Deserializer<'de> {
 
 /// deserialize f64 from string or float
 pub(crate) fn deserialize_f64<'de, D>(deserializer: D) -> Result<f64, D::Error>
-where D: Deserializer<'de> {
+where
+    D: Deserializer<'de>,
+{
     struct StringOrFloatVisitor;
 
     impl Visitor<'_> for StringOrFloatVisitor {
@@ -234,22 +250,30 @@ where D: Deserializer<'de> {
         }
 
         fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-        where E: de::Error {
+        where
+            E: de::Error,
+        {
             parse_str_into_f64(value)
         }
 
         fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
-        where E: de::Error {
+        where
+            E: de::Error,
+        {
             Ok(value)
         }
 
         fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
-        where E: de::Error {
+        where
+            E: de::Error,
+        {
             Ok(value as f64)
         }
 
         fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
-        where E: de::Error {
+        where
+            E: de::Error,
+        {
             Ok(value as f64)
         }
     }

--- a/src/aggregation/segment_agg_result.rs
+++ b/src/aggregation/segment_agg_result.rs
@@ -52,7 +52,8 @@ pub(crate) trait CollectorClone {
 }
 
 impl<T> CollectorClone for T
-where T: 'static + SegmentAggregationCollector + Clone
+where
+    T: 'static + SegmentAggregationCollector + Clone,
 {
     fn clone_box(&self) -> Box<dyn SegmentAggregationCollector> {
         Box::new(self.clone())

--- a/src/collector/custom_score_top_collector.rs
+++ b/src/collector/custom_score_top_collector.rs
@@ -8,7 +8,8 @@ pub(crate) struct CustomScoreTopCollector<TCustomScorer, TScore = Score> {
 }
 
 impl<TCustomScorer, TScore> CustomScoreTopCollector<TCustomScorer, TScore>
-where TScore: Clone + PartialOrd
+where
+    TScore: Clone + PartialOrd,
 {
     pub(crate) fn new(
         custom_scorer: TCustomScorer,
@@ -113,7 +114,8 @@ where
 }
 
 impl<F, TScore> CustomSegmentScorer<TScore> for F
-where F: 'static + FnMut(DocId) -> TScore
+where
+    F: 'static + FnMut(DocId) -> TScore,
 {
     fn score(&mut self, doc: DocId) -> TScore {
         (self)(doc)

--- a/src/collector/facet_collector.rs
+++ b/src/collector/facet_collector.rs
@@ -218,7 +218,9 @@ impl FacetCollector {
     /// If you need the correct number of unique documents for two such facets,
     /// just add them in a separate `FacetCollector`.
     pub fn add_facet<T>(&mut self, facet_from: T)
-    where Facet: From<T> {
+    where
+        Facet: From<T>,
+    {
         let facet = Facet::from(facet_from);
         for old_facet in &self.facets {
             assert!(
@@ -431,7 +433,9 @@ impl FacetCounts {
     /// Returns an iterator over all of the facet count pairs inside this result.
     /// See the documentation for [`FacetCollector`] for a usage example.
     pub fn get<T>(&self, facet_from: T) -> FacetChildIterator<'_>
-    where Facet: From<T> {
+    where
+        Facet: From<T>,
+    {
         let facet = Facet::from(facet_from);
         let lower_bound = Bound::Excluded(facet.clone());
         let upper_bound = if facet.is_root() {
@@ -450,7 +454,9 @@ impl FacetCounts {
     /// Returns a vector of top `k` facets with their counts, sorted highest-to-lowest by counts.
     /// See the documentation for [`FacetCollector`] for a usage example.
     pub fn top_k<T>(&self, facet: T, k: usize) -> Vec<(&Facet, u64)>
-    where Facet: From<T> {
+    where
+        Facet: From<T>,
+    {
         let mut heap = BinaryHeap::with_capacity(k);
         let mut it = self.get(facet);
 

--- a/src/collector/filter_collector_wrapper.rs
+++ b/src/collector/filter_collector_wrapper.rs
@@ -67,7 +67,8 @@ use crate::{DocId, Score, SegmentReader};
 /// [`FastValue`][crate::fastfield::FastValue] trait, e.g. `u64` but not `&[u8]`.
 /// To filter based on a bytes fast field, use a [`BytesFilterCollector`] instead.
 pub struct FilterCollector<TCollector, TPredicate, TPredicateValue>
-where TPredicate: 'static + Clone
+where
+    TPredicate: 'static + Clone,
 {
     field: String,
     collector: TCollector,
@@ -227,7 +228,8 @@ where
 /// # }
 /// ```
 pub struct BytesFilterCollector<TCollector, TPredicate>
-where TPredicate: 'static + Clone
+where
+    TPredicate: 'static + Clone,
 {
     field: String,
     collector: TCollector,
@@ -290,7 +292,8 @@ where
 }
 
 pub struct BytesFilterSegmentCollector<TSegmentCollector, TPredicate>
-where TPredicate: 'static
+where
+    TPredicate: 'static,
 {
     column_opt: Option<BytesColumn>,
     segment_collector: TSegmentCollector,

--- a/src/collector/top_collector.rs
+++ b/src/collector/top_collector.rs
@@ -75,7 +75,8 @@ pub(crate) struct TopCollector<T> {
 }
 
 impl<T> TopCollector<T>
-where T: PartialOrd + Clone
+where
+    T: PartialOrd + Clone,
 {
     /// Creates a top collector, with a number of documents equal to "limit".
     ///

--- a/src/collector/tweak_score_top_collector.rs
+++ b/src/collector/tweak_score_top_collector.rs
@@ -8,7 +8,8 @@ pub(crate) struct TweakedScoreTopCollector<TScoreTweaker, TScore = Score> {
 }
 
 impl<TScoreTweaker, TScore> TweakedScoreTopCollector<TScoreTweaker, TScore>
-where TScore: Clone + PartialOrd
+where
+    TScore: Clone + PartialOrd,
 {
     pub fn new(
         score_tweaker: TScoreTweaker,
@@ -116,7 +117,8 @@ where
 }
 
 impl<F, TScore> ScoreSegmentTweaker<TScore> for F
-where F: 'static + FnMut(DocId, Score) -> TScore
+where
+    F: 'static + FnMut(DocId, Score) -> TScore,
 {
     fn score(&mut self, doc: DocId, score: Score) -> TScore {
         (self)(doc, score)

--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -232,7 +232,8 @@ pub trait DirectoryClone {
 }
 
 impl<T> DirectoryClone for T
-where T: 'static + Directory + Clone
+where
+    T: 'static + Directory + Clone,
 {
     fn box_clone(&self) -> Box<dyn Directory> {
         Box::new(self.clone())

--- a/src/postings/block_search.rs
+++ b/src/postings/block_search.rs
@@ -10,7 +10,7 @@ use crate::postings::compression::COMPRESSION_BLOCK_SIZE;
 //       .take_while(|&&val| val < target)
 //       .count()
 /// ```
-/// 
+///
 /// the `start` argument is just used to hint that the response is
 /// greater than beyond `start`. The implementation may or may not use
 /// it for optimization.

--- a/src/query/query.rs
+++ b/src/query/query.rs
@@ -169,7 +169,8 @@ pub trait QueryClone {
 }
 
 impl<T> QueryClone for T
-where T: 'static + Query + Clone
+where
+    T: 'static + Query + Clone,
 {
     fn box_clone(&self) -> Box<dyn Query> {
         Box::new(self.clone())

--- a/src/query/union/buffered_union.rs
+++ b/src/query/union/buffered_union.rs
@@ -14,7 +14,9 @@ const HORIZON: u32 = 64u32 * HORIZON_NUM_TINYBITSETS as u32;
 //
 // Also, it does not "yield" any elements.
 fn unordered_drain_filter<T, P>(v: &mut Vec<T>, mut predicate: P)
-where P: FnMut(&mut T) -> bool {
+where
+    P: FnMut(&mut T) -> bool,
+{
     let mut i = 0;
     while i < v.len() {
         if predicate(&mut v[i]) {

--- a/src/query/union/mod.rs
+++ b/src/query/union/mod.rs
@@ -70,7 +70,9 @@ mod tests {
         }
     }
     fn aux_test_union_with_constructor<F>(constructor: F, docs_list: &[Vec<DocId>])
-    where F: Fn(&[Vec<DocId>]) -> Box<dyn DocSet> {
+    where
+        F: Fn(&[Vec<DocId>]) -> Box<dyn DocSet>,
+    {
         let mut val_set: BTreeSet<u32> = BTreeSet::new();
         for vs in docs_list {
             for &v in vs {

--- a/src/schema/document/de.rs
+++ b/src/schema/document/de.rs
@@ -70,7 +70,8 @@ impl From<io::Error> for DeserializeError {
 pub trait DocumentDeserialize: Sized {
     /// Attempts to deserialize Self from a given document deserializer.
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: DocumentDeserializer<'de>;
+    where
+        D: DocumentDeserializer<'de>;
 }
 
 /// A deserializer that can walk through each entry in the document.
@@ -91,7 +92,8 @@ pub trait DocumentDeserializer<'de> {
 pub trait ValueDeserialize: Sized {
     /// Attempts to deserialize Self from a given value deserializer.
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de>;
+    where
+        D: ValueDeserializer<'de>;
 }
 
 /// A value deserializer.
@@ -131,7 +133,8 @@ pub trait ValueDeserializer<'de> {
 
     /// Attempts to deserialize the value using a given visitor.
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, DeserializeError>
-    where V: ValueVisitor;
+    where
+        V: ValueVisitor;
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -249,14 +252,18 @@ pub trait ValueVisitor {
     #[inline]
     /// Called when the deserializer visits an array.
     fn visit_array<'de, A>(&self, _access: A) -> Result<Self::Value, DeserializeError>
-    where A: ArrayAccess<'de> {
+    where
+        A: ArrayAccess<'de>,
+    {
         Err(DeserializeError::UnsupportedType(ValueType::Array))
     }
 
     #[inline]
     /// Called when the deserializer visits a object value.
     fn visit_object<'de, A>(&self, _access: A) -> Result<Self::Value, DeserializeError>
-    where A: ObjectAccess<'de> {
+    where
+        A: ObjectAccess<'de>,
+    {
         Err(DeserializeError::UnsupportedType(ValueType::Object))
     }
 }
@@ -300,7 +307,8 @@ pub struct BinaryDocumentDeserializer<'de, R> {
 }
 
 impl<'de, R> BinaryDocumentDeserializer<'de, R>
-where R: Read
+where
+    R: Read,
 {
     /// Attempts to create a new document deserializer from a given reader.
     pub(crate) fn from_reader(
@@ -325,7 +333,8 @@ where R: Read
 }
 
 impl<'de, R> DocumentDeserializer<'de> for BinaryDocumentDeserializer<'de, R>
-where R: Read
+where
+    R: Read,
 {
     #[inline]
     fn size_hint(&self) -> usize {
@@ -357,7 +366,8 @@ pub struct BinaryValueDeserializer<'de, R> {
 }
 
 impl<'de, R> BinaryValueDeserializer<'de, R>
-where R: Read
+where
+    R: Read,
 {
     /// Attempts to create a new value deserializer from a given reader.
     fn from_reader(
@@ -424,7 +434,8 @@ where R: Read
 }
 
 impl<'de, R> ValueDeserializer<'de> for BinaryValueDeserializer<'de, R>
-where R: Read
+where
+    R: Read,
 {
     fn deserialize_null(self) -> Result<(), DeserializeError> {
         self.validate_type(ValueType::Null)?;
@@ -496,7 +507,9 @@ where R: Read
     }
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, DeserializeError>
-    where V: ValueVisitor {
+    where
+        V: ValueVisitor,
+    {
         match self.value_type {
             ValueType::Null => visitor.visit_null(),
             ValueType::String => {
@@ -584,7 +597,8 @@ pub struct BinaryArrayDeserializer<'de, R> {
 }
 
 impl<'de, R> BinaryArrayDeserializer<'de, R>
-where R: Read
+where
+    R: Read,
 {
     /// Attempts to create a new array deserializer from a given reader.
     fn from_reader(
@@ -609,7 +623,8 @@ where R: Read
 }
 
 impl<'de, R> ArrayAccess<'de> for BinaryArrayDeserializer<'de, R>
-where R: Read
+where
+    R: Read,
 {
     #[inline]
     fn size_hint(&self) -> usize {
@@ -642,7 +657,8 @@ pub struct BinaryObjectDeserializer<'de, R> {
 }
 
 impl<'de, R> BinaryObjectDeserializer<'de, R>
-where R: Read
+where
+    R: Read,
 {
     /// Attempts to create a new object deserializer from a given reader.
     fn from_reader(
@@ -655,7 +671,8 @@ where R: Read
 }
 
 impl<'de, R> ObjectAccess<'de> for BinaryObjectDeserializer<'de, R>
-where R: Read
+where
+    R: Read,
 {
     #[inline]
     /// A indicator as to how many values are in the object.
@@ -690,7 +707,9 @@ where R: Read
 impl ValueDeserialize for String {
     #[inline]
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         deserializer.deserialize_string()
     }
 }
@@ -698,7 +717,9 @@ impl ValueDeserialize for String {
 impl ValueDeserialize for u64 {
     #[inline]
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         deserializer.deserialize_u64()
     }
 }
@@ -706,7 +727,9 @@ impl ValueDeserialize for u64 {
 impl ValueDeserialize for i64 {
     #[inline]
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         deserializer.deserialize_i64()
     }
 }
@@ -714,7 +737,9 @@ impl ValueDeserialize for i64 {
 impl ValueDeserialize for f64 {
     #[inline]
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         deserializer.deserialize_f64()
     }
 }
@@ -722,7 +747,9 @@ impl ValueDeserialize for f64 {
 impl ValueDeserialize for DateTime {
     #[inline]
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         deserializer.deserialize_datetime()
     }
 }
@@ -730,7 +757,9 @@ impl ValueDeserialize for DateTime {
 impl ValueDeserialize for Ipv6Addr {
     #[inline]
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         deserializer.deserialize_ip_address()
     }
 }
@@ -738,7 +767,9 @@ impl ValueDeserialize for Ipv6Addr {
 impl ValueDeserialize for Facet {
     #[inline]
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         deserializer.deserialize_facet()
     }
 }
@@ -746,7 +777,9 @@ impl ValueDeserialize for Facet {
 impl ValueDeserialize for Vec<u8> {
     #[inline]
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         deserializer.deserialize_bytes()
     }
 }
@@ -754,7 +787,9 @@ impl ValueDeserialize for Vec<u8> {
 impl ValueDeserialize for PreTokenizedString {
     #[inline]
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         deserializer.deserialize_pre_tokenized_string()
     }
 }
@@ -767,7 +802,9 @@ impl<T: ValueDeserialize> ValueVisitor for VecVisitor<T> {
     type Value = Vec<T>;
 
     fn visit_array<'de, A>(&self, mut access: A) -> Result<Self::Value, DeserializeError>
-    where A: ArrayAccess<'de> {
+    where
+        A: ArrayAccess<'de>,
+    {
         let mut entries = Vec::with_capacity(access.size_hint());
         while let Some(value) = access.next_element()? {
             entries.push(value);
@@ -778,7 +815,9 @@ impl<T: ValueDeserialize> ValueVisitor for VecVisitor<T> {
 impl<T: ValueDeserialize> ValueDeserialize for Vec<T> {
     #[inline]
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         deserializer.deserialize_any(VecVisitor(PhantomData))
     }
 }
@@ -788,7 +827,9 @@ impl<T: ValueDeserialize> ValueVisitor for BTreeMapVisitor<T> {
     type Value = BTreeMap<String, T>;
 
     fn visit_object<'de, A>(&self, mut access: A) -> Result<Self::Value, DeserializeError>
-    where A: ObjectAccess<'de> {
+    where
+        A: ObjectAccess<'de>,
+    {
         let mut entries = BTreeMap::new();
         while let Some((key, value)) = access.next_entry()? {
             entries.insert(key, value);
@@ -799,7 +840,9 @@ impl<T: ValueDeserialize> ValueVisitor for BTreeMapVisitor<T> {
 impl<T: ValueDeserialize> ValueDeserialize for BTreeMap<String, T> {
     #[inline]
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         deserializer.deserialize_any(BTreeMapVisitor(PhantomData))
     }
 }
@@ -809,7 +852,9 @@ impl<T: ValueDeserialize> ValueVisitor for HashMapVisitor<T> {
     type Value = HashMap<String, T>;
 
     fn visit_object<'de, A>(&self, mut access: A) -> Result<Self::Value, DeserializeError>
-    where A: ObjectAccess<'de> {
+    where
+        A: ObjectAccess<'de>,
+    {
         let mut entries = HashMap::with_capacity(access.size_hint());
         while let Some((key, value)) = access.next_entry()? {
             entries.insert(key, value);
@@ -820,7 +865,9 @@ impl<T: ValueDeserialize> ValueVisitor for HashMapVisitor<T> {
 impl<T: ValueDeserialize> ValueDeserialize for HashMap<String, T> {
     #[inline]
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         deserializer.deserialize_any(HashMapVisitor(PhantomData))
     }
 }
@@ -830,7 +877,9 @@ impl<T: ValueDeserialize> ValueVisitor for KeyValuesVecVisitor<T> {
     type Value = Vec<(String, T)>;
 
     fn visit_object<'de, A>(&self, mut access: A) -> Result<Self::Value, DeserializeError>
-    where A: ObjectAccess<'de> {
+    where
+        A: ObjectAccess<'de>,
+    {
         let mut entries = Vec::with_capacity(access.size_hint());
         while let Some(entry) = access.next_entry()? {
             entries.push(entry);
@@ -841,7 +890,9 @@ impl<T: ValueDeserialize> ValueVisitor for KeyValuesVecVisitor<T> {
 impl<T: ValueDeserialize> ValueDeserialize for Vec<(String, T)> {
     #[inline]
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         deserializer.deserialize_any(KeyValuesVecVisitor(PhantomData))
     }
 }

--- a/src/schema/document/default_document.rs
+++ b/src/schema/document/default_document.rs
@@ -68,7 +68,9 @@ impl CompactDoc {
 
     /// Adding a facet to the document.
     pub fn add_facet<F>(&mut self, field: Field, path: F)
-    where Facet: From<F> {
+    where
+        Facet: From<F>,
+    {
         let facet = Facet::from(path);
         self.add_leaf_field_value(field, ReferenceValueLeaf::Facet(facet.encoded_str()));
     }
@@ -377,7 +379,9 @@ impl Eq for CompactDoc {}
 
 impl DocumentDeserialize for CompactDoc {
     fn deserialize<'de, D>(mut deserializer: D) -> Result<Self, DeserializeError>
-    where D: DocumentDeserializer<'de> {
+    where
+        D: DocumentDeserializer<'de>,
+    {
         let mut doc = CompactDoc::default();
         // TODO: Deserializing into OwnedValue is wasteful. The deserializer should be able to work
         // on slices and referenced data.

--- a/src/schema/document/existing_type_impls.rs
+++ b/src/schema/document/existing_type_impls.rs
@@ -196,7 +196,9 @@ impl<'a> Value<'a> for &'a PreTokenizedString {
 
 impl ValueDeserialize for serde_json::Value {
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         struct SerdeValueVisitor;
 
         impl ValueVisitor for SerdeValueVisitor {
@@ -232,7 +234,9 @@ impl ValueDeserialize for serde_json::Value {
             }
 
             fn visit_array<'de, A>(&self, mut access: A) -> Result<Self::Value, DeserializeError>
-            where A: ArrayAccess<'de> {
+            where
+                A: ArrayAccess<'de>,
+            {
                 let mut elements = Vec::with_capacity(access.size_hint());
 
                 while let Some(value) = access.next_element()? {
@@ -243,7 +247,9 @@ impl ValueDeserialize for serde_json::Value {
             }
 
             fn visit_object<'de, A>(&self, mut access: A) -> Result<Self::Value, DeserializeError>
-            where A: ObjectAccess<'de> {
+            where
+                A: ObjectAccess<'de>,
+            {
                 let mut object = serde_json::Map::with_capacity(access.size_hint());
 
                 while let Some((key, value)) = access.next_entry()? {
@@ -287,7 +293,9 @@ impl Document for BTreeMap<Field, crate::schema::OwnedValue> {
 }
 impl DocumentDeserialize for BTreeMap<Field, crate::schema::OwnedValue> {
     fn deserialize<'de, D>(mut deserializer: D) -> Result<Self, DeserializeError>
-    where D: DocumentDeserializer<'de> {
+    where
+        D: DocumentDeserializer<'de>,
+    {
         let mut document = BTreeMap::new();
 
         while let Some((field, value)) = deserializer.next_field()? {
@@ -313,7 +321,9 @@ impl Document for HashMap<Field, crate::schema::OwnedValue> {
 }
 impl DocumentDeserialize for HashMap<Field, crate::schema::OwnedValue> {
     fn deserialize<'de, D>(mut deserializer: D) -> Result<Self, DeserializeError>
-    where D: DocumentDeserializer<'de> {
+    where
+        D: DocumentDeserializer<'de>,
+    {
         let mut document = HashMap::with_capacity(deserializer.size_hint());
 
         while let Some((field, value)) = deserializer.next_field()? {

--- a/src/schema/document/mod.rs
+++ b/src/schema/document/mod.rs
@@ -184,11 +184,13 @@ use super::*;
 pub trait Document: Send + Sync + 'static {
     /// The value of the field.
     type Value<'a>: Value<'a> + Clone
-    where Self: 'a;
+    where
+        Self: 'a;
 
     /// The iterator over all of the fields and values within the doc.
     type FieldsValuesIter<'a>: Iterator<Item = (Field, Self::Value<'a>)>
-    where Self: 'a;
+    where
+        Self: 'a;
 
     /// Get an iterator iterating over all fields and values in a document.
     fn iter_fields_and_values(&self) -> Self::FieldsValuesIter<'_>;

--- a/src/schema/document/owned_value.rs
+++ b/src/schema/document/owned_value.rs
@@ -83,7 +83,9 @@ impl<'a> Value<'a> for &'a OwnedValue {
 
 impl ValueDeserialize for OwnedValue {
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
-    where D: ValueDeserializer<'de> {
+    where
+        D: ValueDeserializer<'de>,
+    {
         struct Visitor;
 
         impl ValueVisitor for Visitor {
@@ -137,7 +139,9 @@ impl ValueDeserialize for OwnedValue {
             }
 
             fn visit_array<'de, A>(&self, mut access: A) -> Result<Self::Value, DeserializeError>
-            where A: ArrayAccess<'de> {
+            where
+                A: ArrayAccess<'de>,
+            {
                 let mut elements = Vec::with_capacity(access.size_hint());
 
                 while let Some(value) = access.next_element()? {
@@ -148,7 +152,9 @@ impl ValueDeserialize for OwnedValue {
             }
 
             fn visit_object<'de, A>(&self, mut access: A) -> Result<Self::Value, DeserializeError>
-            where A: ObjectAccess<'de> {
+            where
+                A: ObjectAccess<'de>,
+            {
                 let mut elements = Vec::with_capacity(access.size_hint());
 
                 while let Some((key, value)) = access.next_entry()? {
@@ -167,7 +173,9 @@ impl Eq for OwnedValue {}
 
 impl serde::Serialize for OwnedValue {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: serde::Serializer {
+    where
+        S: serde::Serializer,
+    {
         use serde::ser::SerializeMap;
         match *self {
             OwnedValue::Null => serializer.serialize_unit(),
@@ -204,7 +212,9 @@ impl serde::Serialize for OwnedValue {
 
 impl<'de> serde::Deserialize<'de> for OwnedValue {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
+    where
+        D: serde::Deserializer<'de>,
+    {
         struct ValueVisitor;
 
         impl<'de> serde::de::Visitor<'de> for ValueVisitor {
@@ -239,12 +249,16 @@ impl<'de> serde::Deserialize<'de> for OwnedValue {
             }
 
             fn visit_unit<E>(self) -> Result<Self::Value, E>
-            where E: serde::de::Error {
+            where
+                E: serde::de::Error,
+            {
                 Ok(OwnedValue::Null)
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where A: SeqAccess<'de> {
+            where
+                A: SeqAccess<'de>,
+            {
                 let mut elements = Vec::with_capacity(seq.size_hint().unwrap_or_default());
 
                 while let Some(value) = seq.next_element()? {
@@ -255,7 +269,9 @@ impl<'de> serde::Deserialize<'de> for OwnedValue {
             }
 
             fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-            where A: MapAccess<'de> {
+            where
+                A: MapAccess<'de>,
+            {
                 let mut object = map.size_hint().map(Vec::with_capacity).unwrap_or_default();
                 while let Some((key, value)) = map.next_entry()? {
                     object.push((key, value));

--- a/src/schema/document/se.rs
+++ b/src/schema/document/se.rs
@@ -16,7 +16,8 @@ pub struct BinaryDocumentSerializer<'se, W> {
 }
 
 impl<'se, W> BinaryDocumentSerializer<'se, W>
-where W: Write
+where
+    W: Write,
 {
     /// Creates a new serializer with a provided writer.
     pub(crate) fn new(writer: &'se mut W, schema: &'se Schema) -> Self {
@@ -27,7 +28,9 @@ where W: Write
     /// to the writer.
     #[inline]
     pub(crate) fn serialize_doc<D>(&mut self, doc: &D) -> io::Result<()>
-    where D: Document {
+    where
+        D: Document,
+    {
         let stored_field_values = || {
             doc.iter_fields_and_values()
                 .filter(|(field, _)| self.schema.get_field_entry(*field).is_stored())
@@ -71,7 +74,8 @@ pub struct BinaryValueSerializer<'se, W> {
 }
 
 impl<'se, W> BinaryValueSerializer<'se, W>
-where W: Write
+where
+    W: Write,
 {
     /// Creates a new serializer with a provided writer.
     pub(crate) fn new(writer: &'se mut W) -> Self {
@@ -89,10 +93,7 @@ where W: Write
 
     /// Attempts to serialize a given value and write the output
     /// to the writer.
-    pub(crate) fn serialize_value<'a, V>(
-        &mut self,
-        value: ReferenceValue<'a, V>,
-    ) -> io::Result<()>
+    pub(crate) fn serialize_value<'a, V>(&mut self, value: ReferenceValue<'a, V>) -> io::Result<()>
     where
         V: Value<'a>,
     {
@@ -180,7 +181,8 @@ pub struct BinaryArraySerializer<'se, W> {
 }
 
 impl<'se, W> BinaryArraySerializer<'se, W>
-where W: Write
+where
+    W: Write,
 {
     /// Creates a new array serializer and writes the length of the array to the writer.
     pub(crate) fn begin(length: usize, writer: &'se mut W) -> io::Result<Self> {
@@ -195,10 +197,7 @@ where W: Write
 
     /// Attempts to serialize a given value and write the output
     /// to the writer.
-    pub(crate) fn serialize_value<'a, V>(
-        &mut self,
-        value: ReferenceValue<'a, V>,
-    ) -> io::Result<()>
+    pub(crate) fn serialize_value<'a, V>(&mut self, value: ReferenceValue<'a, V>) -> io::Result<()>
     where
         V: Value<'a>,
     {
@@ -230,7 +229,8 @@ pub struct BinaryObjectSerializer<'se, W> {
 }
 
 impl<'se, W> BinaryObjectSerializer<'se, W>
-where W: Write
+where
+    W: Write,
 {
     /// Creates a new object serializer and writes the length of the object to the writer.
     pub(crate) fn begin(length: usize, writer: &'se mut W) -> io::Result<Self> {

--- a/src/schema/document/value.rs
+++ b/src/schema/document/value.rs
@@ -336,7 +336,8 @@ impl<'a> ReferenceValueLeaf<'a> {
 /// A enum representing a value for tantivy to index.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ReferenceValue<'a, V>
-where V: Value<'a> + ?Sized
+where
+    V: Value<'a> + ?Sized,
 {
     /// A null value.
     Leaf(ReferenceValueLeaf<'a>),
@@ -347,7 +348,8 @@ where V: Value<'a> + ?Sized
 }
 
 impl<'a, V> ReferenceValue<'a, V>
-where V: Value<'a>
+where
+    V: Value<'a>,
 {
     #[inline]
     /// Returns if the value is `null` or not.

--- a/src/schema/facet.rs
+++ b/src/schema/facet.rs
@@ -84,7 +84,9 @@ impl Facet {
     /// contains a `/`, it should be escaped
     /// using an anti-slash `\`.
     pub fn from_text<T>(path: &T) -> Result<Facet, FacetParseError>
-    where T: ?Sized + AsRef<str> {
+    where
+        T: ?Sized + AsRef<str>,
+    {
         #[derive(Copy, Clone)]
         enum State {
             Escaped,
@@ -217,14 +219,18 @@ fn escape_slashes(s: &str) -> Cow<'_, str> {
 
 impl Serialize for Facet {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: Serializer {
+    where
+        S: Serializer,
+    {
         serializer.serialize_str(&self.to_string())
     }
 }
 
 impl<'de> Deserialize<'de> for Facet {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: Deserializer<'de> {
+    where
+        D: Deserializer<'de>,
+    {
         <Cow<'de, str> as Deserialize<'de>>::deserialize(deserializer).and_then(|path| {
             Facet::from_text(&*path).map_err(|err| D::Error::custom(err.to_string()))
         })

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -372,7 +372,9 @@ impl Schema {
 
 impl Serialize for Schema {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: Serializer {
+    where
+        S: Serializer,
+    {
         let mut seq = serializer.serialize_seq(Some(self.0.fields.len()))?;
         for e in &self.0.fields {
             seq.serialize_element(e)?;
@@ -383,7 +385,9 @@ impl Serialize for Schema {
 
 impl<'de> Deserialize<'de> for Schema {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: Deserializer<'de> {
+    where
+        D: Deserializer<'de>,
+    {
         struct SchemaVisitor;
 
         impl<'de> Visitor<'de> for SchemaVisitor {
@@ -394,7 +398,9 @@ impl<'de> Deserialize<'de> for Schema {
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where A: SeqAccess<'de> {
+            where
+                A: SeqAccess<'de>,
+            {
                 let mut schema = SchemaBuilder {
                     fields: Vec::with_capacity(seq.size_hint().unwrap_or(0)),
                     fields_map: HashMap::with_capacity(seq.size_hint().unwrap_or(0)),

--- a/src/schema/term.rs
+++ b/src/schema/term.rs
@@ -22,7 +22,8 @@ use crate::DateTime;
 /// The serialized value `ValueBytes` is considered everything after the 4 first bytes (term id).
 #[derive(Clone)]
 pub struct Term<B = Vec<u8>>(B)
-where B: AsRef<[u8]>;
+where
+    B: AsRef<[u8]>;
 
 /// The number of bytes used as metadata by `Term`.
 const TERM_METADATA_LENGTH: usize = 5;
@@ -285,7 +286,8 @@ impl Term {
 }
 
 impl<B> Term<B>
-where B: AsRef<[u8]>
+where
+    B: AsRef<[u8]>,
 {
     /// Wraps a object holding bytes
     pub fn wrap(data: B) -> Term<B> {
@@ -344,10 +346,12 @@ where B: AsRef<[u8]>
 /// The nested ValueBytes in JSON is never of type JSON. (there's no recursion)
 #[derive(Clone)]
 pub struct ValueBytes<B>(B)
-where B: AsRef<[u8]>;
+where
+    B: AsRef<[u8]>;
 
 impl<B> ValueBytes<B>
-where B: AsRef<[u8]>
+where
+    B: AsRef<[u8]>,
 {
     /// Wraps a object holding bytes
     pub fn wrap(data: B) -> ValueBytes<B> {
@@ -567,7 +571,8 @@ where B: AsRef<[u8]>
 }
 
 impl<B> Ord for Term<B>
-where B: AsRef<[u8]>
+where
+    B: AsRef<[u8]>,
 {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.serialized_term().cmp(other.serialized_term())
@@ -575,7 +580,8 @@ where B: AsRef<[u8]>
 }
 
 impl<B> PartialOrd for Term<B>
-where B: AsRef<[u8]>
+where
+    B: AsRef<[u8]>,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
@@ -583,7 +589,8 @@ where B: AsRef<[u8]>
 }
 
 impl<B> PartialEq for Term<B>
-where B: AsRef<[u8]>
+where
+    B: AsRef<[u8]>,
 {
     fn eq(&self, other: &Self) -> bool {
         self.serialized_term() == other.serialized_term()
@@ -593,7 +600,8 @@ where B: AsRef<[u8]>
 impl<B> Eq for Term<B> where B: AsRef<[u8]> {}
 
 impl<B> Hash for Term<B>
-where B: AsRef<[u8]>
+where
+    B: AsRef<[u8]>,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.as_ref().hash(state)
@@ -608,7 +616,8 @@ fn write_opt<T: std::fmt::Debug>(f: &mut fmt::Formatter, val_opt: Option<T>) -> 
 }
 
 impl<B> fmt::Debug for Term<B>
-where B: AsRef<[u8]>
+where
+    B: AsRef<[u8]>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let field_id = self.field().field_id();

--- a/src/termdict/fst_termdict/streamer.rs
+++ b/src/termdict/fst_termdict/streamer.rs
@@ -11,14 +11,16 @@ use crate::termdict::TermOrdinal;
 /// `TermStreamerBuilder` is a helper object used to define
 /// a range of terms that should be streamed.
 pub struct TermStreamerBuilder<'a, A = AlwaysMatch>
-where A: Automaton
+where
+    A: Automaton,
 {
     fst_map: &'a TermDictionary,
     stream_builder: StreamBuilder<'a, A>,
 }
 
 impl<'a, A> TermStreamerBuilder<'a, A>
-where A: Automaton
+where
+    A: Automaton,
 {
     pub(crate) fn new(fst_map: &'a TermDictionary, stream_builder: StreamBuilder<'a, A>) -> Self {
         TermStreamerBuilder {
@@ -73,7 +75,8 @@ where A: Automaton
 /// `TermStreamer` acts as a cursor over a range of terms of a segment.
 /// Terms are guaranteed to be sorted.
 pub struct TermStreamer<'a, A = AlwaysMatch>
-where A: Automaton
+where
+    A: Automaton,
 {
     pub(crate) fst_map: &'a TermDictionary,
     pub(crate) stream: Stream<'a, A>,
@@ -83,7 +86,8 @@ where A: Automaton
 }
 
 impl<A> TermStreamer<'_, A>
-where A: Automaton
+where
+    A: Automaton,
 {
     /// Advance position the stream on the next item.
     /// Before the first call to `.advance()`, the stream

--- a/src/termdict/fst_termdict/termdict.rs
+++ b/src/termdict/fst_termdict/termdict.rs
@@ -28,7 +28,8 @@ pub struct TermDictionaryBuilder<W> {
 }
 
 impl<W> TermDictionaryBuilder<W>
-where W: Write
+where
+    W: Write,
 {
     /// Creates a new `TermDictionaryBuilder`
     pub fn create(w: W) -> io::Result<Self> {

--- a/src/termdict/mod.rs
+++ b/src/termdict/mod.rs
@@ -152,7 +152,9 @@ impl TermDictionary {
     /// Returns a search builder, to stream all of the terms
     /// within the Automaton
     pub fn search<'a, A: Automaton + 'a>(&'a self, automaton: A) -> TermStreamerBuilder<'a, A>
-    where A::State: Clone {
+    where
+        A::State: Clone,
+    {
         self.0.search(automaton)
     }
 

--- a/src/tokenizer/ngram_tokenizer.rs
+++ b/src/tokenizer/ngram_tokenizer.rs
@@ -205,7 +205,8 @@ struct StutteringIterator<T> {
 }
 
 impl<T> StutteringIterator<T>
-where T: Iterator<Item = usize>
+where
+    T: Iterator<Item = usize>,
 {
     pub fn new(mut underlying: T, min_gram: usize, max_gram: usize) -> StutteringIterator<T> {
         assert!(min_gram > 0);
@@ -234,7 +235,8 @@ where T: Iterator<Item = usize>
 }
 
 impl<T> Iterator for StutteringIterator<T>
-where T: Iterator<Item = usize>
+where
+    T: Iterator<Item = usize>,
 {
     type Item = (usize, usize);
 

--- a/src/tokenizer/tokenizer_manager.rs
+++ b/src/tokenizer/tokenizer_manager.rs
@@ -33,7 +33,9 @@ impl TokenizerManager {
 
     /// Registers a new tokenizer associated with a given name.
     pub fn register<T>(&self, tokenizer_name: &str, tokenizer: T)
-    where TextAnalyzer: From<T> {
+    where
+        TextAnalyzer: From<T>,
+    {
         let boxed_tokenizer: TextAnalyzer = TextAnalyzer::from(tokenizer);
         self.tokenizers
             .write()

--- a/sstable/src/delta.rs
+++ b/sstable/src/delta.rs
@@ -13,7 +13,8 @@ const VINT_MODE: u8 = 1u8;
 const BLOCK_LEN: usize = 4_000;
 
 pub struct DeltaWriter<W, TValueWriter>
-where W: io::Write
+where
+    W: io::Write,
 {
     block: Vec<u8>,
     write: CountingWriter<BufWriter<W>>,
@@ -135,7 +136,8 @@ pub struct DeltaReader<TValueReader> {
 }
 
 impl<TValueReader> DeltaReader<TValueReader>
-where TValueReader: value::ValueReader
+where
+    TValueReader: value::ValueReader,
 {
     pub fn new(reader: OwnedBytes) -> Self {
         DeltaReader {

--- a/sstable/src/dictionary.rs
+++ b/sstable/src/dictionary.rs
@@ -639,10 +639,7 @@ impl<TSSTable: SSTable> Dictionary<TSSTable> {
 
     /// Returns a search builder, to stream all of the terms
     /// within the Automaton
-    pub fn search<'a, A: Automaton + 'a>(
-        &'a self,
-        automaton: A,
-    ) -> StreamerBuilder<'a, TSSTable, A>
+    pub fn search<'a, A: Automaton + 'a>(&'a self, automaton: A) -> StreamerBuilder<'a, TSSTable, A>
     where
         A::State: Clone,
     {

--- a/sstable/src/lib.rs
+++ b/sstable/src/lib.rs
@@ -184,7 +184,8 @@ pub struct Reader<TValueReader> {
 }
 
 impl<TValueReader> Reader<TValueReader>
-where TValueReader: ValueReader
+where
+    TValueReader: ValueReader,
 {
     pub fn advance(&mut self) -> io::Result<bool> {
         if !self.delta_reader.advance()? {
@@ -217,7 +218,8 @@ impl<TValueReader> AsRef<[u8]> for Reader<TValueReader> {
 }
 
 pub struct Writer<W, TValueWriter>
-where W: io::Write
+where
+    W: io::Write,
 {
     previous_key: Vec<u8>,
     index_builder: SSTableIndexBuilder,

--- a/sstable/src/streamer.rs
+++ b/sstable/src/streamer.rs
@@ -179,7 +179,8 @@ where
 }
 
 impl<TSSTable> Streamer<'_, TSSTable, AlwaysMatch>
-where TSSTable: SSTable
+where
+    TSSTable: SSTable,
 {
     pub fn empty() -> Self {
         Streamer {

--- a/stacker/src/arena_hashmap.rs
+++ b/stacker/src/arena_hashmap.rs
@@ -63,7 +63,9 @@ impl ArenaHashMap {
     /// Get a value associated to a key.
     #[inline]
     pub fn get<V>(&self, key: &[u8]) -> Option<V>
-    where V: Copy + 'static {
+    where
+        V: Copy + 'static,
+    {
         self.shared_arena_hashmap.get(key, &self.memory_arena)
     }
 
@@ -79,7 +81,9 @@ impl ArenaHashMap {
     /// `Some(previous_value)`.
     #[inline]
     pub fn mutate_or_create<V>(&mut self, key: &[u8], updater: impl FnMut(Option<V>) -> V)
-    where V: Copy + 'static {
+    where
+        V: Copy + 'static,
+    {
         self.shared_arena_hashmap
             .mutate_or_create(key, &mut self.memory_arena, updater);
     }

--- a/stacker/src/shared_arena_hashmap.rs
+++ b/stacker/src/shared_arena_hashmap.rs
@@ -266,7 +266,9 @@ impl SharedArenaHashMap {
     /// Get a value associated to a key.
     #[inline]
     pub fn get<V>(&self, key: &[u8], memory_arena: &MemoryArena) -> Option<V>
-    where V: Copy + 'static {
+    where
+        V: Copy + 'static,
+    {
         let hash = self.get_hash(key);
         let mut probe = self.probe(hash);
         loop {


### PR DESCRIPTION
## Summary
- drop custom `rustfmt` settings and reformat with the tool's default style
- note plan to clean up `std::iter` warnings

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688bb804891483229644b015688da1dd