### PR TITLE
Expand preflight script test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Yeehaw 0.25
 - remove legacy Makefile in favor of direct cargo commands.
 - remove custom `rustfmt` configuration in favor of default formatting.
 - run preflight script in CI via GitHub Action.
+- expand preflight script to run all workspace tests and doctests.
 
 Yeehaw 0.24
 ================================

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2,4 +2,5 @@
 set -euo pipefail
 
 cargo fmt --all -- --check
-cargo test --tests --lib
+cargo test --workspace --all-features
+cargo test --doc --workspace --all-features


### PR DESCRIPTION
## Summary
- ensure preflight runs all workspace tests and doctests
- document expanded preflight coverage

## Testing
- `./scripts/preflight.sh` *(fails: `#![feature]` may not be used on the stable release channel)*

------
https://chatgpt.com/codex/tasks/task_e_688bd757c5548322af269f1ef807c11f