### PR TITLE
Update examples to use yeehaw crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ have been removed to keep the changelog focused on Yeehaw's history.
 - make zstd optional in sstable [#2633](https://github.com/quickwit-oss/yeehaw/pull/2633)(@Parth)
 - replace lingering references from `tantivy` to `yeehaw`.
 - rename benchmark imports to use the `yeehaw` crate.
+- update examples to import the `yeehaw` crate instead of `tantivy`.
 
 ## Features/Improvements
 - add docs/example and Vec<u32> values to sstable [#2660](https://github.com/quickwit-oss/yeehaw/pull/2660)(@PSeitz)

--- a/examples/aggregation.rs
+++ b/examples/aggregation.rs
@@ -7,14 +7,14 @@
 // ---
 
 use serde_json::{Deserializer, Value};
-use tantivy::aggregation::agg_req::Aggregations;
-use tantivy::aggregation::agg_result::AggregationResults;
-use tantivy::aggregation::AggregationCollector;
-use tantivy::query::AllQuery;
-use tantivy::schema::{self, IndexRecordOption, Schema, TextFieldIndexing, FAST};
-use tantivy::{Index, IndexWriter, TantivyDocument};
+use yeehaw::aggregation::agg_req::Aggregations;
+use yeehaw::aggregation::agg_result::AggregationResults;
+use yeehaw::aggregation::AggregationCollector;
+use yeehaw::query::AllQuery;
+use yeehaw::schema::{self, IndexRecordOption, Schema, TextFieldIndexing, FAST};
+use yeehaw::{Index, IndexWriter, TantivyDocument};
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // # Create Schema
     //
     // Lets create a schema for a footwear shop, with 4 fields: name, category, stock and price.
@@ -28,7 +28,7 @@ fn main() -> tantivy::Result<()> {
     // - `raw` tokenizer
     //
     // The tokenizer is set to "raw", because the fast field uses the same dictionary as the
-    // inverted index. (This behaviour will change in tantivy 0.20, where the fast field will
+    // inverted index. (This behaviour will change in yeehaw 0.20, where the fast field will
     // always be raw tokenized independent from the regular tokenizing)
     //
     let text_fieldtype = schema::TextOptions::default()

--- a/examples/basic_search.rs
+++ b/examples/basic_search.rs
@@ -1,7 +1,7 @@
 // # Basic Example
 //
 // This example covers the basic functionalities of
-// tantivy.
+// yeehaw.
 //
 // We will :
 // - define our schema
@@ -11,21 +11,21 @@
 // - retrieve the best document's original content.
 
 // ---
-// Importing tantivy...
-use tantivy::collector::TopDocs;
-use tantivy::query::QueryParser;
-use tantivy::schema::*;
-use tantivy::{doc, Index, IndexWriter, ReloadPolicy};
+// Importing yeehaw...
 use tempfile::TempDir;
+use yeehaw::collector::TopDocs;
+use yeehaw::query::QueryParser;
+use yeehaw::schema::*;
+use yeehaw::{doc, Index, IndexWriter, ReloadPolicy};
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // Let's create a temporary directory for the
     // sake of this example
     let index_path = TempDir::new()?;
 
     // # Defining the schema
     //
-    // The Tantivy index requires a very strict schema.
+    // The Yeehaw index requires a very strict schema.
     // The schema declares which fields are in the index,
     // and for each field, its type and "the way it should
     // be indexed".
@@ -72,7 +72,7 @@ fn main() -> tantivy::Result<()> {
     // This single `IndexWriter` is already
     // multithreaded.
     //
-    // Here we give tantivy a budget of `50MB`.
+    // Here we give yeehaw a budget of `50MB`.
     // Using a bigger memory_arena for the indexer may increase
     // throughput, but 50 MB is already plenty.
     let mut index_writer: IndexWriter = index.writer(50_000_000)?;
@@ -98,7 +98,7 @@ fn main() -> tantivy::Result<()> {
     // ... and add it to the `IndexWriter`.
     index_writer.add_document(old_man_doc)?;
 
-    // For convenience, tantivy also comes with a macro to
+    // For convenience, yeehaw also comes with a macro to
     // reduce the boilerplate above.
     index_writer.add_document(doc!(
     title => "Of Mice and Men",
@@ -123,8 +123,8 @@ fn main() -> tantivy::Result<()> {
     ))?;
 
     // This is an example, so we will only index 3 documents
-    // here. You can check out tantivy's tutorial to index
-    // the English wikipedia. Tantivy's indexing is rather fast.
+    // here. You can check out yeehaw's tutorial to index
+    // the English wikipedia. Yeehaw's indexing is rather fast.
     // Indexing 5 million articles of the English wikipedia takes
     // around 3 minutes on my computer!
 
@@ -146,7 +146,7 @@ fn main() -> tantivy::Result<()> {
     // persistently indexed.
     //
     // In the scenario of a crash or a power failure,
-    // tantivy behaves as if it has rolled back to its last
+    // yeehaw behaves as if it has rolled back to its last
     // commit.
 
     // # Searching
@@ -185,7 +185,7 @@ fn main() -> tantivy::Result<()> {
 
     // The query parser can interpret human queries.
     // Here, if the user does not specify which
-    // field they want to search, tantivy will search
+    // field they want to search, yeehaw will search
     // in both title and body.
     let query_parser = QueryParser::for_index(&index, vec![title, body]);
 
@@ -211,7 +211,7 @@ fn main() -> tantivy::Result<()> {
     let top_docs = searcher.search(&query, &TopDocs::with_limit(10))?;
 
     // The actual documents still need to be
-    // retrieved from Tantivy's store.
+    // retrieved from Yeehaw's store.
     //
     // Since the body field was not configured as stored,
     // the document returned will only contain

--- a/examples/custom_collector.rs
+++ b/examples/custom_collector.rs
@@ -4,17 +4,17 @@
 // collector. As an example, we will compute a collector
 // that computes the standard deviation of a given fast field.
 //
-// Of course, you can have a look at the tantivy's built-in collectors
+// Of course, you can have a look at the yeehaw's built-in collectors
 // such as the `CountCollector` for more examples.
 
 use columnar::Column;
 // ---
-// Importing tantivy...
-use tantivy::collector::{Collector, SegmentCollector};
-use tantivy::index::SegmentReader;
-use tantivy::query::QueryParser;
-use tantivy::schema::{Schema, FAST, INDEXED, TEXT};
-use tantivy::{doc, Index, IndexWriter, Score};
+// Importing yeehaw...
+use yeehaw::collector::{Collector, SegmentCollector};
+use yeehaw::index::SegmentReader;
+use yeehaw::query::QueryParser;
+use yeehaw::schema::{Schema, FAST, INDEXED, TEXT};
+use yeehaw::{doc, Index, IndexWriter, Score};
 
 #[derive(Default)]
 struct Stats {
@@ -71,7 +71,7 @@ impl Collector for StatsCollector {
         &self,
         _segment_local_id: u32,
         segment_reader: &SegmentReader,
-    ) -> tantivy::Result<StatsSegmentCollector> {
+    ) -> yeehaw::Result<StatsSegmentCollector> {
         let fast_field_reader = segment_reader.fast_fields().u64(&self.field)?;
         Ok(StatsSegmentCollector {
             fast_field_reader,
@@ -84,7 +84,7 @@ impl Collector for StatsCollector {
         false
     }
 
-    fn merge_fruits(&self, segment_stats: Vec<Option<Stats>>) -> tantivy::Result<Option<Stats>> {
+    fn merge_fruits(&self, segment_stats: Vec<Option<Stats>>) -> yeehaw::Result<Option<Stats>> {
         let mut stats = Stats::default();
         for segment_stats in segment_stats.into_iter().flatten() {
             stats.count += segment_stats.count;
@@ -119,10 +119,10 @@ impl SegmentCollector for StatsSegmentCollector {
     }
 }
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // # Defining the schema
     //
-    // The Tantivy index requires a very strict schema.
+    // The Yeehaw index requires a very strict schema.
     // The schema declares which fields are in the index,
     // and for each field, its type and "the way it should
     // be indexed".

--- a/examples/custom_tokenizer.rs
+++ b/examples/custom_tokenizer.rs
@@ -2,16 +2,16 @@
 //
 // In this example, we'll see how to define a tokenizer
 // by creating a custom `NgramTokenizer`.
-use tantivy::collector::TopDocs;
-use tantivy::query::QueryParser;
-use tantivy::schema::*;
-use tantivy::tokenizer::NgramTokenizer;
-use tantivy::{doc, Index, IndexWriter};
+use yeehaw::collector::TopDocs;
+use yeehaw::query::QueryParser;
+use yeehaw::schema::*;
+use yeehaw::tokenizer::NgramTokenizer;
+use yeehaw::{doc, Index, IndexWriter};
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // # Defining the schema
     //
-    // The Tantivy index requires a very strict schema.
+    // The Yeehaw index requires a very strict schema.
     // The schema declares which fields are in the index,
     // and for each field, its type and "the way it should
     // be indexed".
@@ -93,7 +93,7 @@ fn main() -> tantivy::Result<()> {
 
     // The query parser can interpret human queries.
     // Here, if the user does not specify which
-    // field they want to search, tantivy will search
+    // field they want to search, yeehaw will search
     // in both title and body.
     let query_parser = QueryParser::for_index(&index, vec![title, body]);
 

--- a/examples/date_time_field.rs
+++ b/examples/date_time_field.rs
@@ -2,18 +2,18 @@
 //
 // This example shows how the DateTime field can be used
 
-use tantivy::collector::TopDocs;
-use tantivy::query::QueryParser;
-use tantivy::schema::{DateOptions, Document, Schema, Value, INDEXED, STORED, STRING};
-use tantivy::{Index, IndexWriter, TantivyDocument};
+use yeehaw::collector::TopDocs;
+use yeehaw::query::QueryParser;
+use yeehaw::schema::{DateOptions, Document, Schema, Value, INDEXED, STORED, STRING};
+use yeehaw::{Index, IndexWriter, TantivyDocument};
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // # Defining the schema
     let mut schema_builder = Schema::builder();
     let opts = DateOptions::from(INDEXED)
         .set_stored()
         .set_fast()
-        .set_precision(tantivy::schema::DateTimePrecision::Seconds);
+        .set_precision(yeehaw::schema::DateTimePrecision::Seconds);
     // Add `occurred_at` date field type
     let occurred_at = schema_builder.add_date_field("occurred_at", opts);
     let event_type = schema_builder.add_text_field("event", STRING | STORED);

--- a/examples/deleting_updating_documents.rs
+++ b/examples/deleting_updating_documents.rs
@@ -1,17 +1,17 @@
 // # Deleting and Updating (?) documents
 //
 // This example explains how to delete and update documents.
-// In fact there is actually no such thing as an update in tantivy.
+// In fact there is actually no such thing as an update in yeehaw.
 //
 // To update a document, you need to delete a document and then reinsert
 // its new version.
 //
 // ---
-// Importing tantivy...
-use tantivy::collector::TopDocs;
-use tantivy::query::TermQuery;
-use tantivy::schema::*;
-use tantivy::{doc, Index, IndexReader, IndexWriter};
+// Importing yeehaw...
+use yeehaw::collector::TopDocs;
+use yeehaw::query::TermQuery;
+use yeehaw::schema::*;
+use yeehaw::{doc, Index, IndexReader, IndexWriter};
 
 // A simple helper function to fetch a single document
 // given its id from our index.
@@ -19,7 +19,7 @@ use tantivy::{doc, Index, IndexReader, IndexWriter};
 fn extract_doc_given_isbn(
     reader: &IndexReader,
     isbn_term: &Term,
-) -> tantivy::Result<Option<TantivyDocument>> {
+) -> yeehaw::Result<Option<TantivyDocument>> {
     let searcher = reader.searcher();
 
     // This is the simplest query you can think of.
@@ -39,14 +39,14 @@ fn extract_doc_given_isbn(
     }
 }
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // # Defining the schema
     //
     // Check out the *basic_search* example if this makes
     // small sense to you.
     let mut schema_builder = Schema::builder();
 
-    // Tantivy does not really have a notion of primary id.
+    // Yeehaw does not really have a notion of primary id.
     // This may change in the future.
     //
     // Still, we can create a `isbn` field and use it as an id. This
@@ -57,7 +57,7 @@ fn main() -> tantivy::Result<()> {
     // running any text processing on it.
     // This is done by associating this field to the tokenizer named `raw`.
     // Rather than building our
-    // [`TextOptions`](//docs.rs/tantivy/~0/tantivy/schema/struct.TextOptions.html) manually, We
+    // [`TextOptions`](//docs.rs/yeehaw/~0/yeehaw/schema/struct.TextOptions.html) manually, We
     // use the `STRING` shortcut. `STRING` stands for indexed (without term frequency or positions)
     // and untokenized.
     //
@@ -102,17 +102,17 @@ fn main() -> tantivy::Result<()> {
     //
     // Here we will want to update the typo in the `Frankenstein` book.
     //
-    // Tantivy does not handle updates directly, we need to delete
+    // Yeehaw does not handle updates directly, we need to delete
     // and reinsert the document.
     //
     // This can be complicated as it means you need to have access
-    // to the entire document. It is good practise to integrate tantivy
+    // to the entire document. It is good practise to integrate yeehaw
     // with a key value store for this reason.
     //
     // To remove one of the document, we just call `delete_term`
     // on its id.
     //
-    // Note that `tantivy` does nothing to enforce the idea that
+    // Note that `yeehaw` does nothing to enforce the idea that
     // there is only one document associated with this id.
     //
     // Also you might have noticed that we apply the delete before

--- a/examples/faceted_search.rs
+++ b/examples/faceted_search.rs
@@ -1,7 +1,7 @@
 // # Faceted Search
 //
 // This example covers the faceted search functionalities of
-// tantivy.
+// yeehaw.
 //
 // We will :
 // - define a text field "name" in our schema
@@ -13,13 +13,13 @@
 //   classifications include the facet.
 //
 // ---
-// Importing tantivy...
-use tantivy::collector::FacetCollector;
-use tantivy::query::{AllQuery, TermQuery};
-use tantivy::schema::*;
-use tantivy::{doc, Index, IndexWriter};
+// Importing yeehaw...
+use yeehaw::collector::FacetCollector;
+use yeehaw::query::{AllQuery, TermQuery};
+use yeehaw::schema::*;
+use yeehaw::{doc, Index, IndexWriter};
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // Let's create a temporary directory for the sake of this example
     let mut schema_builder = Schema::builder();
 
@@ -32,7 +32,7 @@ fn main() -> tantivy::Result<()> {
 
     let mut index_writer: IndexWriter = index.writer(30_000_000)?;
 
-    // For convenience, tantivy also comes with a macro to
+    // For convenience, yeehaw also comes with a macro to
     // reduce the boilerplate above.
     index_writer.add_document(doc!(
         name => "Cat",

--- a/examples/faceted_search_with_tweaked_score.rs
+++ b/examples/faceted_search_with_tweaked_score.rs
@@ -1,7 +1,7 @@
 // # Faceted Search With Tweak Score
 //
 // This example covers the faceted search functionalities of
-// tantivy.
+// yeehaw.
 //
 // We will :
 // - define a text field "name" in our schema
@@ -9,12 +9,12 @@
 
 use std::collections::HashSet;
 
-use tantivy::collector::TopDocs;
-use tantivy::query::BooleanQuery;
-use tantivy::schema::*;
-use tantivy::{doc, DocId, Index, IndexWriter, Score, SegmentReader};
+use yeehaw::collector::TopDocs;
+use yeehaw::query::BooleanQuery;
+use yeehaw::schema::*;
+use yeehaw::{doc, DocId, Index, IndexWriter, Score, SegmentReader};
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     let mut schema_builder = Schema::builder();
 
     let title = schema_builder.add_text_field("title", STORED);

--- a/examples/fuzzy_search.rs
+++ b/examples/fuzzy_search.rs
@@ -1,7 +1,7 @@
 // # Basic Example
 //
 // This example covers the basic functionalities of
-// tantivy.
+// yeehaw.
 //
 // We will :
 // - define our schema
@@ -10,21 +10,21 @@
 // - search for the best document matching a basic query
 // - retrieve the best document's original content.
 // ---
-// Importing tantivy...
-use tantivy::collector::{Count, TopDocs};
-use tantivy::query::FuzzyTermQuery;
-use tantivy::schema::*;
-use tantivy::{doc, Index, IndexWriter, ReloadPolicy};
+// Importing yeehaw...
 use tempfile::TempDir;
+use yeehaw::collector::{Count, TopDocs};
+use yeehaw::query::FuzzyTermQuery;
+use yeehaw::schema::*;
+use yeehaw::{doc, Index, IndexWriter, ReloadPolicy};
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // Let's create a temporary directory for the
     // sake of this example
     let index_path = TempDir::new()?;
 
     // # Defining the schema
     //
-    // The Tantivy index requires a very strict schema.
+    // The Yeehaw index requires a very strict schema.
     // The schema declares which fields are in the index,
     // and for each field, its type and "the way it should
     // be indexed".
@@ -63,7 +63,7 @@ fn main() -> tantivy::Result<()> {
     // This single `IndexWriter` is already
     // multithreaded.
     //
-    // Here we give tantivy a budget of `50MB`.
+    // Here we give yeehaw a budget of `50MB`.
     // Using a bigger memory_arena for the indexer may increase
     // throughput, but 50 MB is already plenty.
     let mut index_writer: IndexWriter = index.writer(50_000_000)?;
@@ -105,7 +105,7 @@ fn main() -> tantivy::Result<()> {
     // persistently indexed.
     //
     // In the scenario of a crash or a power failure,
-    // tantivy behaves as if it has rolled back to its last
+    // yeehaw behaves as if it has rolled back to its last
     // commit.
 
     // # Searching
@@ -152,7 +152,7 @@ fn main() -> tantivy::Result<()> {
         assert_eq!(top_docs.len(), 3);
         for (score, doc_address) in top_docs {
             // Note that the score is not lower for the fuzzy hit.
-            // There's an issue open for that: https://github.com/quickwit-oss/tantivy/issues/563
+            // There's an issue open for that: https://github.com/quickwit-oss/yeehaw/issues/563
             let retrieved_doc: TantivyDocument = searcher.doc(doc_address)?;
             println!("score {score:?} doc {}", retrieved_doc.to_json(&schema));
             // score 1.0 doc {"title":["The Diary of Muadib"]}

--- a/examples/index_from_multiple_threads.rs
+++ b/examples/index_from_multiple_threads.rs
@@ -1,12 +1,12 @@
 // # Indexing from different threads.
 //
 // It is fairly common to have to index from different threads.
-// Tantivy forbids to create more than one `IndexWriter` at a time.
+// Yeehaw forbids to create more than one `IndexWriter` at a time.
 //
 // This `IndexWriter` itself has its own multithreaded layer, so managing your own
 // indexing threads will not help. However, it can still be useful for some applications.
 //
-// For instance, if preparing documents to send to tantivy before indexing is the bottleneck of
+// For instance, if preparing documents to send to yeehaw before indexing is the bottleneck of
 // your application, it is reasonable to have multiple threads.
 //
 // Another very common reason to want to index from multiple threads, is implementing a webserver
@@ -24,15 +24,15 @@
 // from several threads possible.
 
 // ---
-// Importing tantivy...
+// Importing yeehaw...
 use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Duration;
 
-use tantivy::schema::{Schema, STORED, TEXT};
-use tantivy::{doc, Index, IndexWriter, Opstamp, TantivyError};
+use yeehaw::schema::{Schema, STORED, TEXT};
+use yeehaw::{doc, Index, IndexWriter, Opstamp, TantivyError};
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // # Defining the schema
     let mut schema_builder = Schema::builder();
     let title = schema_builder.add_text_field("title", TEXT | STORED);
@@ -69,7 +69,7 @@ fn main() -> tantivy::Result<()> {
 
     // # Second indexing thread.
     let index_writer_clone_2 = index_writer.clone();
-    // For convenience, tantivy also comes with a macro to
+    // For convenience, yeehaw also comes with a macro to
     // reduce the boilerplate above.
     thread::spawn(move || {
         // we index 100 times the document... for the sake of the example.

--- a/examples/index_with_json.rs
+++ b/examples/index_with_json.rs
@@ -1,9 +1,9 @@
-use tantivy::schema::*;
+use yeehaw::schema::*;
 
 // # Document from json
 //
 // For convenience, `Document` can be parsed directly from json.
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // Let's first define a schema and an index.
     // Check out the basic example if this is confusing to you.
     //

--- a/examples/integer_range_search.rs
+++ b/examples/integer_range_search.rs
@@ -4,10 +4,10 @@ use std::ops::Bound;
 //
 // Below is an example of creating an indexed integer field in your schema
 // You can use RangeQuery to get a Count of all occurrences in a given range.
-use tantivy::collector::Count;
-use tantivy::query::RangeQuery;
-use tantivy::schema::{Schema, INDEXED};
-use tantivy::{doc, Index, IndexWriter, Result, Term};
+use yeehaw::collector::Count;
+use yeehaw::query::RangeQuery;
+use yeehaw::schema::{Schema, INDEXED};
+use yeehaw::{doc, Index, IndexWriter, Result, Term};
 
 fn main() -> Result<()> {
     // For the sake of simplicity, this schema will only have 1 field

--- a/examples/ip_field.rs
+++ b/examples/ip_field.rs
@@ -3,12 +3,12 @@
 // This example shows how the ip field can be used
 // with IpV6 and IpV4.
 
-use tantivy::collector::{Count, TopDocs};
-use tantivy::query::QueryParser;
-use tantivy::schema::{Schema, FAST, INDEXED, STORED, STRING};
-use tantivy::{Index, IndexWriter, TantivyDocument};
+use yeehaw::collector::{Count, TopDocs};
+use yeehaw::query::QueryParser;
+use yeehaw::schema::{Schema, FAST, INDEXED, STORED, STRING};
+use yeehaw::{Index, IndexWriter, TantivyDocument};
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // # Defining the schema
     // We set the IP field as `INDEXED`, so it can be searched
     // `FAST` will create a fast field. The fast field will be used to execute search queries.

--- a/examples/iterating_docs_and_positions.rs
+++ b/examples/iterating_docs_and_positions.rs
@@ -1,19 +1,19 @@
 // # Iterating docs and positions.
 //
-// At its core of tantivy, relies on a data structure
+// At its core of yeehaw, relies on a data structure
 // called an inverted index.
 //
 // This example shows how to manually iterate through
 // the list of documents containing a term, getting
 // its term frequency, and accessing its positions.
 
-use tantivy::postings::Postings;
+use yeehaw::postings::Postings;
 // ---
-// Importing tantivy...
-use tantivy::schema::*;
-use tantivy::{doc, DocSet, Index, IndexWriter, TERMINATED};
+// Importing yeehaw...
+use yeehaw::schema::*;
+use yeehaw::{doc, DocSet, Index, IndexWriter, TERMINATED};
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // We first create a schema for the sake of the
     // example. Check the `basic_search` example for more information.
     let mut schema_builder = Schema::builder();
@@ -35,7 +35,7 @@ fn main() -> tantivy::Result<()> {
 
     let searcher = reader.searcher();
 
-    // A tantivy index is actually a collection of segments.
+    // A yeehaw index is actually a collection of segments.
     // Similarly, a searcher just wraps a list `segment_reader`.
     //
     // (Because we indexed a very small number of documents over one thread
@@ -53,7 +53,7 @@ fn main() -> tantivy::Result<()> {
         let term_the = Term::from_field_text(title, "the");
 
         // This segment posting object is like a cursor over the documents matching the term.
-        // The `IndexRecordOption` arguments tells tantivy we will be interested in both term
+        // The `IndexRecordOption` arguments tells yeehaw we will be interested in both term
         // frequencies and positions.
         //
         // If you don't need all this information, you may get better performance by decompressing
@@ -97,8 +97,8 @@ fn main() -> tantivy::Result<()> {
 
     // Some other powerful operations (especially `.skip_to`) may be useful to consume these
     // posting lists rapidly.
-    // You can check for them in the [`DocSet`](https://docs.rs/tantivy/~0/tantivy/trait.DocSet.html) trait
-    // and the [`Postings`](https://docs.rs/tantivy/~0/tantivy/trait.Postings.html) trait
+    // You can check for them in the [`DocSet`](https://docs.rs/yeehaw/~0/yeehaw/trait.DocSet.html) trait
+    // and the [`Postings`](https://docs.rs/yeehaw/~0/yeehaw/trait.Postings.html) trait
 
     // Also, for some VERY specific high performance use case like an OLAP analysis of logs,
     // you can get better performance by accessing directly the blocks of doc ids.
@@ -110,7 +110,7 @@ fn main() -> tantivy::Result<()> {
         let inverted_index = segment_reader.inverted_index(title)?;
 
         // This segment posting object is like a cursor over the documents matching the term.
-        // The `IndexRecordOption` arguments tells tantivy we will be interested in both term
+        // The `IndexRecordOption` arguments tells yeehaw we will be interested in both term
         // frequencies and positions.
         //
         // If you don't need all this information, you may get better performance by decompressing

--- a/examples/json_field.rs
+++ b/examples/json_field.rs
@@ -1,15 +1,15 @@
 // # Json field example
 //
 // This example shows how the json field can be used
-// to make tantivy partially schemaless by setting it as
+// to make yeehaw partially schemaless by setting it as
 // default query parser field.
 
-use tantivy::collector::{Count, TopDocs};
-use tantivy::query::QueryParser;
-use tantivy::schema::{Schema, FAST, STORED, STRING, TEXT};
-use tantivy::{Index, IndexWriter, TantivyDocument};
+use yeehaw::collector::{Count, TopDocs};
+use yeehaw::query::QueryParser;
+use yeehaw::schema::{Schema, FAST, STORED, STRING, TEXT};
+use yeehaw::{Index, IndexWriter, TantivyDocument};
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // # Defining the schema
     let mut schema_builder = Schema::builder();
     schema_builder.add_date_field("timestamp", FAST | STORED);

--- a/examples/phrase_prefix_search.rs
+++ b/examples/phrase_prefix_search.rs
@@ -1,8 +1,8 @@
-use tantivy::collector::TopDocs;
-use tantivy::query::QueryParser;
-use tantivy::schema::*;
-use tantivy::{doc, Index, IndexWriter, ReloadPolicy, Result};
 use tempfile::TempDir;
+use yeehaw::collector::TopDocs;
+use yeehaw::query::QueryParser;
+use yeehaw::schema::*;
+use yeehaw::{doc, Index, IndexWriter, ReloadPolicy, Result};
 
 fn main() -> Result<()> {
     let index_path = TempDir::new()?;

--- a/examples/pre_tokenized_text.rs
+++ b/examples/pre_tokenized_text.rs
@@ -5,16 +5,16 @@
 // tokens by some external tool.
 //
 // In this example we will:
-// - use tantivy tokenizer to create tokens and load them directly into tantivy,
+// - use yeehaw tokenizer to create tokens and load them directly into yeehaw,
 // - import tokenized text straight from json,
 // - perform a search on documents with pre-tokenized text
 
-use tantivy::collector::{Count, TopDocs};
-use tantivy::query::TermQuery;
-use tantivy::schema::*;
-use tantivy::tokenizer::{PreTokenizedString, SimpleTokenizer, Token, TokenStream, Tokenizer};
-use tantivy::{doc, Index, IndexWriter, ReloadPolicy};
 use tempfile::TempDir;
+use yeehaw::collector::{Count, TopDocs};
+use yeehaw::query::TermQuery;
+use yeehaw::schema::*;
+use yeehaw::tokenizer::{PreTokenizedString, SimpleTokenizer, Token, TokenStream, Tokenizer};
+use yeehaw::{doc, Index, IndexWriter, ReloadPolicy};
 
 fn pre_tokenize_text(text: &str) -> Vec<Token> {
     let mut tokenizer = SimpleTokenizer::default();
@@ -26,7 +26,7 @@ fn pre_tokenize_text(text: &str) -> Vec<Token> {
     tokens
 }
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     let index_path = TempDir::new()?;
 
     let mut schema_builder = Schema::builder();

--- a/examples/snippet.rs
+++ b/examples/snippet.rs
@@ -6,15 +6,15 @@
 // The keyword searched by the user are highlighted with a `<b>` tag.
 
 // ---
-// Importing tantivy...
-use tantivy::collector::TopDocs;
-use tantivy::query::QueryParser;
-use tantivy::schema::*;
-use tantivy::snippet::{Snippet, SnippetGenerator};
-use tantivy::{doc, Index, IndexWriter};
+// Importing yeehaw...
 use tempfile::TempDir;
+use yeehaw::collector::TopDocs;
+use yeehaw::query::QueryParser;
+use yeehaw::schema::*;
+use yeehaw::snippet::{Snippet, SnippetGenerator};
+use yeehaw::{doc, Index, IndexWriter};
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // Let's create a temporary directory for the
     // sake of this example
     let index_path = TempDir::new()?;

--- a/examples/stop_words.rs
+++ b/examples/stop_words.rs
@@ -1,7 +1,7 @@
 // # Stop Words Example
 //
 // This example covers the basic usage of stop words
-// with tantivy
+// with yeehaw
 //
 // We will :
 // - define our schema
@@ -10,18 +10,18 @@
 // - index few documents in our index
 
 // ---
-// Importing tantivy...
-use tantivy::collector::TopDocs;
-use tantivy::query::QueryParser;
-use tantivy::schema::*;
-use tantivy::tokenizer::*;
-use tantivy::{doc, Index, IndexWriter};
+// Importing yeehaw...
+use yeehaw::collector::TopDocs;
+use yeehaw::query::QueryParser;
+use yeehaw::schema::*;
+use yeehaw::tokenizer::*;
+use yeehaw::{doc, Index, IndexWriter};
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // this example assumes you understand the content in `basic_search`
     let mut schema_builder = Schema::builder();
 
-    // This configures your custom options for how tantivy will
+    // This configures your custom options for how yeehaw will
     // store and process your content in the index; The key
     // to note is that we are setting the tokenizer to `stoppy`
     // which will be defined and registered below.

--- a/examples/warmer.rs
+++ b/examples/warmer.rs
@@ -2,11 +2,11 @@ use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock, Weak};
 
-use tantivy::collector::TopDocs;
-use tantivy::index::SegmentId;
-use tantivy::query::QueryParser;
-use tantivy::schema::{Schema, FAST, TEXT};
-use tantivy::{
+use yeehaw::collector::TopDocs;
+use yeehaw::index::SegmentId;
+use yeehaw::query::QueryParser;
+use yeehaw::schema::{Schema, FAST, TEXT};
+use yeehaw::{
     doc, DocAddress, DocId, Index, IndexWriter, Opstamp, Searcher, SearcherGeneration,
     SegmentReader, Warmer,
 };
@@ -49,7 +49,7 @@ impl DynamicPriceColumn {
     }
 }
 impl Warmer for DynamicPriceColumn {
-    fn warm(&self, searcher: &Searcher) -> tantivy::Result<()> {
+    fn warm(&self, searcher: &Searcher) -> yeehaw::Result<()> {
         for segment in searcher.segment_readers() {
             let product_id_reader = segment
                 .fast_fields()
@@ -122,7 +122,7 @@ impl PriceFetcher for ExternalPriceTable {
     }
 }
 
-fn main() -> tantivy::Result<()> {
+fn main() -> yeehaw::Result<()> {
     // Declaring our schema.
     let mut schema_builder = Schema::builder();
     // The product id is assumed to be a primary id for our external price source.


### PR DESCRIPTION
## Summary
- update all example imports and comments to reference `yeehaw` instead of `tantivy`
- add changelog entry for the example updates

## Testing
- `cargo test` *(fails: doctests still reference the old `tantivy` crate)*
- `./scripts/preflight.sh` *(fails: `#![feature(test)]` requires nightly and doctests reference `tantivy`)*

------
https://chatgpt.com/codex/tasks/task_e_688bebaafac48322ac663578df1f63d3