### PR TITLE
chore: remove obsolete list_columns todo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@ have been removed to keep the changelog focused on Yeehaw's history.
 - simplify CI by removing the separate test workflow in favor of preflight checks, and restrict preflight to pull requests to avoid duplicate runs.
 - remove long-running tests from CI.
 - drop coverage workflow from CI
+- remove outdated TODO for columnar `list_columns` and document error handling follow-up.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -51,3 +51,5 @@ This inventory captures the direction of the rewrite and the major tasks require
     - Update types and crates (e.g. `TantivyDocument`, `tantivy-fst`) to use `yeehaw` naming.
 11. **Rename subcrate benchmarks**
     - Update benchmark crates (e.g. bitpacker, common, sstable) to use `yeehaw` naming once subcrate packages are renamed.
+12. **Improve error handling in `ColumnarReader::iter_columns`**
+    - Replace `unwrap` usage with a fallible API that reports unknown column types.

--- a/TODO.txt
+++ b/TODO.txt
@@ -12,7 +12,6 @@ remove fast field reader
 find a way to unify the two DateTime.
 readd type check in the filter wrapper
 
-add unit test on columnar list columns.
 
 make sure sort works
 

--- a/columnar/src/columnar/reader/mod.rs
+++ b/columnar/src/columnar/reader/mod.rs
@@ -155,7 +155,6 @@ impl ColumnarReader {
         }))
     }
 
-    // TODO Add unit tests
     pub fn list_columns(&self) -> io::Result<Vec<(String, DynamicColumnHandle)>> {
         Ok(self.iter_columns()?.collect())
     }


### PR DESCRIPTION
## Summary
- remove outdated TODO comment for `ColumnarReader::list_columns`
- drop completed task from TODO list and track follow-up work in inventory
- document change in changelog

## Testing
- `./scripts/preflight.sh` *(fails: `#![feature]` used on stable release channel)*
- `cargo test --workspace` *(fails: doctests still reference `tantivy` crate)*

------
https://chatgpt.com/codex/tasks/task_e_688d21505d40832289d30be17409b192