### PR TITLE
chore: remove unused std::iter imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ have been removed to keep the changelog focused on Yeehaw's history.
 - remove long-running tests from CI.
 - drop coverage workflow from CI
 - remove outdated TODO for columnar `list_columns` and document error handling follow-up.
+- remove unused `std::iter` imports from test modules.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -43,8 +43,8 @@ This document outlines the long term plan to rewrite this project so that it rel
 8. **Add contributor guidelines** *(done)*
    - Ported the `AGENTS.md` from `tribles-rust` and adapted it for this project.
    - Contributors must run `cargo fmt`, `cargo test` and `./scripts/preflight.sh` before committing.
-9. **Clean up unused imports**
-   - `cargo test` reports several `unused import: std::iter` warnings that should be removed.
+9. **Clean up unused imports** *(done)*
+   - Removed `unused import: std::iter` warnings from tests.
 
 This inventory captures the direction of the rewrite and the major tasks required to make Yeehaw a Trible native search engine.
 10. **Rename remaining `Tantivy` prefixes**

--- a/src/collector/facet_collector.rs
+++ b/src/collector/facet_collector.rs
@@ -490,7 +490,6 @@ impl FacetCounts {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
-    use std::iter;
 
     use columnar::Dictionary;
     use rand::distributions::Uniform;

--- a/src/positions/mod.rs
+++ b/src/positions/mod.rs
@@ -40,9 +40,6 @@ const COMPRESSION_BLOCK_SIZE: usize = BitPacker4x::BLOCK_LEN;
 
 #[cfg(test)]
 pub(crate) mod tests {
-
-    use std::iter;
-
     use proptest::prelude::*;
     use proptest::sample::select;
 

--- a/src/query/boolean_query/block_wand.rs
+++ b/src/query/boolean_query/block_wand.rs
@@ -302,7 +302,6 @@ fn is_sorted<I: Iterator<Item = DocId>>(mut it: I) -> bool {
 mod tests {
     use std::cmp::Ordering;
     use std::collections::BinaryHeap;
-    use std::iter;
 
     use proptest::prelude::*;
 

--- a/src/tokenizer/ascii_folding_filter.rs
+++ b/src/tokenizer/ascii_folding_filter.rs
@@ -1561,8 +1561,6 @@ fn to_ascii(text: &str, output: &mut String) {
 
 #[cfg(test)]
 mod tests {
-    use std::iter;
-
     use super::to_ascii;
     use crate::tokenizer::{AsciiFoldingFilter, RawTokenizer, SimpleTokenizer, TextAnalyzer};
 


### PR DESCRIPTION
## Summary
- remove unnecessary `std::iter` imports from various test modules
- record change in changelog and inventory

## Testing
- `cargo test` *(fails: doctest failed)*
- `./scripts/preflight.sh` *(fails: `#![feature]` may not be used on the stable release channel)*

------
https://chatgpt.com/codex/tasks/task_e_688d27a85a448322b5463cda02975a53