### PR TITLE
docs: clarify deserialization traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@ have been removed to keep the changelog focused on Yeehaw's history.
 - drop coverage workflow from CI
 - remove outdated TODO for columnar `list_columns` and document error handling follow-up.
 - remove unused `std::iter` imports from test modules.
+- expand documentation for document deserialization traits.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -53,3 +53,5 @@ This inventory captures the direction of the rewrite and the major tasks require
     - Update benchmark crates (e.g. bitpacker, common, sstable) to use `yeehaw` naming once subcrate packages are renamed.
 12. **Improve error handling in `ColumnarReader::iter_columns`**
     - Replace `unwrap` usage with a fallible API that reports unknown column types.
+13. **Fix failing doctests after crate rename**
+    - Update examples referencing `tantivy` to `yeehaw` so `cargo test --doc` succeeds.

--- a/src/schema/document/de.rs
+++ b/src/schema/document/de.rs
@@ -64,9 +64,11 @@ impl From<io::Error> for DeserializeError {
     }
 }
 
-/// The core trait for deserializing a document.
+/// Trait implemented by types that can be constructed from a serialized
+/// document.
 ///
-/// TODO: Improve docs
+/// Implementations pull values from a [`DocumentDeserializer`] and
+/// build the type from the extracted fields.
 pub trait DocumentDeserialize: Sized {
     /// Attempts to deserialize Self from a given document deserializer.
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>
@@ -86,9 +88,11 @@ pub trait DocumentDeserializer<'de> {
     fn next_field<V: ValueDeserialize>(&mut self) -> Result<Option<(Field, V)>, DeserializeError>;
 }
 
-/// The core trait for deserializing values.
+/// Trait implemented by types that can be deserialized from a single
+/// value within a document.
 ///
-/// TODO: Improve docs
+/// This is used by [`DocumentDeserializer`] to materialize the value
+/// associated with each field.
 pub trait ValueDeserialize: Sized {
     /// Attempts to deserialize Self from a given value deserializer.
     fn deserialize<'de, D>(deserializer: D) -> Result<Self, DeserializeError>


### PR DESCRIPTION
## Summary
- expand docs for `DocumentDeserialize` and `ValueDeserialize`
- record failing doctests from `tantivy` rename
- note doc change in changelog

## Testing
- `cargo test` *(fails: doctests referencing `tantivy`)*
- `./scripts/preflight.sh` *(fails: `#![feature(test)]` requires nightly when running with `--all-features`)*

------
https://chatgpt.com/codex/tasks/task_e_688d2bff30148322a829139b9c6564d9