### PR TITLE
Improve columnar error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ have been removed to keep the changelog focused on Yeehaw's history.
 - rename benchmark imports to use the `yeehaw` crate.
 - update examples to import the `yeehaw` crate instead of `tantivy`.
 - run preflight tests without enabling the `unstable` feature.
+- handle unknown column codes gracefully in `ColumnarReader::iter_columns`.
 
 ## Features/Improvements
 - add docs/example and Vec<u32> values to sstable [#2660](https://github.com/quickwit-oss/yeehaw/pull/2660)(@PSeitz)
@@ -28,3 +29,4 @@ have been removed to keep the changelog focused on Yeehaw's history.
 - remove outdated TODO for columnar `list_columns` and document error handling follow-up.
 - remove unused `std::iter` imports from test modules.
 - expand documentation for document deserialization traits.
+- reorder inventory tasks to prioritize fixing doctest regressions.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -51,9 +51,9 @@ This inventory captures the direction of the rewrite and the major tasks require
     - Update types and crates (e.g. `TantivyDocument`, `tantivy-fst`) to use `yeehaw` naming.
 11. **Rename subcrate benchmarks**
     - Update benchmark crates (e.g. bitpacker, common, sstable) to use `yeehaw` naming once subcrate packages are renamed.
-12. **Improve error handling in `ColumnarReader::iter_columns`**
-    - Replace `unwrap` usage with a fallible API that reports unknown column types.
-13. **Fix failing doctests after crate rename**
+12. **Fix failing doctests after crate rename**
     - Update examples referencing `tantivy` to `yeehaw` so `cargo test --doc` succeeds.
+13. **Improve error handling in `ColumnarReader::iter_columns`** *(done)*
+    - Replace `unwrap` usage with a fallible API that reports unknown column types.
 14. **Replace nightly benches using `test::Bencher`**
     - Migrate inline benchmarks to a stable harness so the `unstable` feature can be tested on stable Rust.

--- a/columnar/src/columnar/merge/mod.rs
+++ b/columnar/src/columnar/merge/mod.rs
@@ -410,7 +410,8 @@ fn group_columns_for_merge<'a>(
     for (columnar_id, columnar_reader) in columnar_readers.iter().enumerate() {
         let column_name_and_handle = columnar_reader.iter_columns()?;
 
-        for (column_name, handle) in column_name_and_handle {
+        for result in column_name_and_handle {
+            let (column_name, handle) = result?;
             let column_category: ColumnTypeCategory = handle.column_type().into();
             columns
                 .entry((column_name, column_category))


### PR DESCRIPTION
## Summary
- propagate unknown column code errors in columnar iterators
- update call sites to handle fallible iterators
- reorder inventory tasks so doctest fixes take precedence

## Testing
- `cargo fmt --all`
- `cargo test --doc -p yeehaw` *(fails: 47 doctests referencing `tantivy`)*
- `./scripts/preflight.sh` *(fails: doctests referencing `tantivy`)*

------
https://chatgpt.com/codex/tasks/task_e_688d45708fac8322b6b978d684aaaf5e