### PR TITLE
Document Trible-native storage direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ have been removed to keep the changelog focused on Yeehaw's history.
 - reorder inventory tasks to prioritize fixing doctest regressions.
 - remove `quickwit` feature and associated asynchronous APIs.
 - remove obsolete document type codes.
+- capture plan to drop Tantivy's `Directory` layer in favor of Trible-native blob and view APIs.
 - remove delete queue and segment delete tracking; document removal now handled externally by triblespace.
 - remove operation stamp infrastructure in preparation for commit-handle redesign.
 - simplify searcher generation to track segment ids only and drop legacy delete tests.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -16,9 +16,9 @@ This document outlines the long term plan to rewrite this project so that it rel
    - Represent segment lists, schema and other metadata as entities attached to each commit.
    - Replace the `meta.json` file with this trible based representation.
 
-2. **Implement `TribleBlobDirectory`**
-   - Replace the `Directory` abstraction with a backend that reads and writes blobs via the Trible Space `BlobStore`.
-   - Index writers and readers operate on blob handles instead of filesystem paths.
+2. **Adopt Trible-native storage primitives**
+   - Remove the Tantivy `Directory` abstraction and expose the Trible Space blob and view APIs directly to index components.
+   - Provide helper constructors for in-memory, file-backed and object-storage Trible deployments so the search engine never touches filesystem paths itself.
 
 3. **Remove `Opstamp` and use commit handles**
    - Commits record the segments they include.


### PR DESCRIPTION
## Summary
- retitle the roadmap item around storage integration to focus on Trible-native primitives instead of Tantivy directories
- note the directory removal plan in the changelog so contributors see the updated direction

## Testing
- ./scripts/preflight.sh *(fails: query::intersection::tests::test_intersection_skip_against_unoptimized, tests::test_delete_postings1, tests::test_delete_postings2, tests::test_update_via_delete_insert)*

------
https://chatgpt.com/codex/tasks/task_e_68eea66df104832290063abf2cf89b97