### PR TITLE
Clarify roadmap coverage for deletion cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ have been removed to keep the changelog focused on Yeehaw's history.
 - reorder inventory tasks to prioritize fixing doctest regressions.
 - remove `quickwit` feature and associated asynchronous APIs.
 - remove obsolete document type codes.
+- capture plan to drop Tantivy's `Directory` layer in favor of Trible-native blob and view APIs.
+- refine roadmap subtasks for metadata commits, Trible-native storage migration, and removal of legacy GC/tombstone plumbing.
 - remove delete queue and segment delete tracking; document removal now handled externally by triblespace.
 - remove operation stamp infrastructure in preparation for commit-handle redesign.
 - simplify searcher generation to track segment ids only and drop legacy delete tests.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -14,11 +14,15 @@ This document outlines the long term plan to rewrite this project so that it rel
 1. **Store fulltext metadata in commit tribles**
    - Define a `fulltext` attribute in the Trible namespace.
    - Represent segment lists, schema and other metadata as entities attached to each commit.
-   - Replace the `meta.json` file with this trible based representation.
+   - Replace the `meta.json` file with this trible based representation and load metadata from the latest commit handle.
+   - Provide shims for reading legacy indexes long enough to migrate existing data.
 
-2. **Implement `TribleBlobDirectory`**
-   - Replace the `Directory` abstraction with a backend that reads and writes blobs via the Trible Space `BlobStore`.
-   - Index writers and readers operate on blob handles instead of filesystem paths.
+2. **Adopt Trible-native storage primitives**
+   - Replace the Tantivy `Directory` trait with a thin storage module that fetches blobs and views from Trible Space directly.
+   - Update index building, merging and searcher initialization so they operate on append-only segment blobs without filesystem assumptions.
+   - Delete lock file, watcher, atomic write and garbage collection helpers that only exist for mutable directories.
+   - Remove alive-bitset writers/readers and other deletion tombstone plumbing so append-only blobs are the only persistence path.
+   - Provide helper constructors for in-memory, file-backed and object-storage Trible deployments so the search engine never touches filesystem paths itself.
 
 3. **Remove `Opstamp` and use commit handles**
    - Commits record the segments they include.


### PR DESCRIPTION
## Summary
- expand the roadmap storage task to explicitly cover removing garbage collection and tombstone plumbing alongside the directory shim
- update the changelog entry so it reflects the broader cleanup scope for the Trible-native migration roadmap

## Testing
- cargo fmt --all
- cargo test query::intersection::tests::test_intersection_skip_against_unoptimized *(fails: assertion failed: doc <= target)*
- cargo test tests::test_delete_postings1 *(fails: assertion `left == right` failed; left: 1 right: 5)*
- cargo test tests::test_delete_postings2 *(fails: assertion `left == right` failed; left: 8 right: 6)*
- cargo test tests::test_update_via_delete_insert *(fails: assertion `left == right` failed; left: 3 right: 2)*
- ./scripts/preflight.sh *(terminated manually after prolonged test run; prior failures expected from known delete-path regressions)*

------
https://chatgpt.com/codex/tasks/task_e_68eea66df104832290063abf2cf89b97